### PR TITLE
Fixing CORS & offering a config shorthand

### DIFF
--- a/packages/xmcp/src/compiler/get-webpack-config/get-injected-variables.ts
+++ b/packages/xmcp/src/compiler/get-webpack-config/get-injected-variables.ts
@@ -19,6 +19,12 @@ type CorsConfig = {
   maxAge?: number;
 };
 
+const DEFAULT_CORS: CorsConfig = {
+  origin: "*",
+  allowedHeaders: ["content-type", "mcp-session-id", "mcp-protocol-version"],
+  exposedHeaders: ["mcp-session-id"],
+};
+
 /**
  * The XMCP runtime uses variables that are not defined by default.
  *
@@ -29,20 +35,19 @@ export function getInjectedVariables(xmcpConfig: XmcpParsedConfig) {
 
   const definedVariables: Record<string, string | number | boolean> = {};
 
-  if (xmcpConfig["http"]) {
+  const httpConfig = xmcpConfig["http"];
+  if (httpConfig) {
     // define variables
     definedVariables.HTTP_DEBUG = mode === "development";
     let cors: CorsConfig = {};
-    if (typeof xmcpConfig["http"] === "object") {
-      definedVariables.HTTP_PORT = xmcpConfig["http"].port;
+    if (typeof httpConfig === "object") {
+      definedVariables.HTTP_PORT = httpConfig.port;
       definedVariables.HTTP_BODY_SIZE_LIMIT = JSON.stringify(
-        xmcpConfig["http"].bodySizeLimit
+        httpConfig.bodySizeLimit
       );
-      definedVariables.HTTP_ENDPOINT = JSON.stringify(
-        xmcpConfig["http"].endpoint
-      );
+      definedVariables.HTTP_ENDPOINT = JSON.stringify(httpConfig.endpoint);
       definedVariables.HTTP_STATELESS = DEFAULT_HTTP_STATELESS;
-      cors = xmcpConfig["http"].cors || {};
+      cors = httpConfig.cors === true ? DEFAULT_CORS : httpConfig.cors || {};
     } else {
       // http config is boolean
       definedVariables.HTTP_PORT = DEFAULT_HTTP_PORT;

--- a/packages/xmcp/src/compiler/parse-xmcp-config.ts
+++ b/packages/xmcp/src/compiler/parse-xmcp-config.ts
@@ -13,14 +13,17 @@ export const DEFAULT_HTTP_STATELESS = true;
 export const DEFAULT_TOOLS_DIR = "src/tools";
 
 // cors config schema
-const corsConfigSchema = z.object({
-  origin: z.union([z.string(), z.array(z.string()), z.boolean()]).optional(),
-  methods: z.union([z.string(), z.array(z.string())]).optional(),
-  allowedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
-  exposedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
-  credentials: z.boolean().optional(),
-  maxAge: z.number().optional(),
-});
+const corsConfigSchema = z.union([
+  z.object({
+    origin: z.union([z.string(), z.array(z.string()), z.boolean()]).optional(),
+    methods: z.union([z.string(), z.array(z.string())]).optional(),
+    allowedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
+    exposedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
+    credentials: z.boolean().optional(),
+    maxAge: z.number().optional(),
+  }),
+  z.literal(true),
+]);
 
 // oauth endpoints schema
 const oauthEndpointsSchema = z.object({

--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -332,6 +332,11 @@ export class StatelessStreamableHTTPTransport {
   }
 
   private setupRoutes(): void {
+    this.app.options("*", (_req: Request, res: Response) => {
+      // CORS middleware has already run, so we just need to return OK
+      res.status(200).end();
+    })
+
     this.app.get("/health", (_req: Request, res: Response) => {
       res.status(200).json({
         status: "ok",


### PR DESCRIPTION
Hey, love the idea behind this project! I really wanted to build something similar but never got the time so glad to see someone exploring these design ideas :)

I spun up a `create-xmcp-app` and tried accessing it from https://inspector.use-mcp.dev/ but hit a CORS error. That's the first commit.

Second commit is offering folks an easy `"cors": true` config option that sets:

```js
const DEFAULT_CORS: CorsConfig = {
  origin: "*",
  allowedHeaders: ["content-type", "mcp-session-id", "mcp-protocol-version"],
  exposedHeaders: ["mcp-session-id"],
};
```

That was the minimal set needed to get it working. Obviously the full CORS config options are still wired up, it just gives people a way to get something working without having to understand all the settings. And if the MCP spec adds another header, you can add it to `DEFAULT_CORS` and make the upgrade automatic for your users.

Lemme know if you're open to more stuff like this. I'm currently working on https://github.com/modelcontextprotocol/use-mcp which is a web-based MCP client, so I'm keen to see what server-side frameworks pop up around MCP and how best to use them.