### PR TITLE
Fix typos and grammar in docs 'Getting Started' section

### DIFF
--- a/apps/website/src/docs/index.mdx
+++ b/apps/website/src/docs/index.mdx
@@ -34,13 +34,13 @@ You will be asked for the project name and then guided through a series of promp
 
 #### Building with HTTP
 
-The HTTP transport is your go to choice when you want to deploy your MCP on a server. This can be used to create tools like fetching your database or perform fetch operations.
+The HTTP transport is your go-to choice when you want to deploy your MCP on a server. This can be used to create tools like fetching your database or performing fetch operations.
 
 `xmcp` uses stateless mode. This means that every time you call a tool, a new transport will be instantiated. There is no tracking of sessions or state.
 
 #### Building with STDIO
 
-The STDIO transport is useful when you want to use your MCP server locally, useful for enabling your AI to perform operations on your machine. For example, you can create tools like searching and compressing images on a folder.
+The STDIO transport is useful when you want to use your MCP server locally, useful for enabling your AI to perform operations on your machine. For example, you can create tools like searching and compressing images in a folder.
 You can also publish the server as a package on NPM.
 
 ## Project structure
@@ -110,7 +110,7 @@ export default async function greet({ name }: InferSchema<typeof schema>) {
 The schema object defines the tool's parameters with:
 
 - **Key**: Parameter name.
-- **Value**: Zod schema with `.describe()` for documentation. This will be visibile through the inspector.
+- **Value**: Zod schema with `.describe()` for documentation. This will be visible through the inspector.
 - **Purpose**: Type validation and automatic parameter documentation.
 
 #### 2. Metadata


### PR DESCRIPTION
Hey! 👋
So happy for the release! it’s a really nice project.
While going through the docs, I spotted a few small typos and fixed them:

```
- Added missing hyphen in “go-to choice”
- Fixed verb agreement in a sentence about fetch operations
- Corrected a typo (“visibile” → “visible”)
- Changed “compressing images on a folder” to “compressing images in a folder” for clarity
```
Thanks for all the work on this — excited to see where xmcp goes next 🤍