### PR TITLE
Compiler config polish + restructuring

### DIFF
--- a/packages/xmcp/src/compiler/compiler-context.ts
+++ b/packages/xmcp/src/compiler/compiler-context.ts
@@ -1,6 +1,6 @@
 import { CompilerMode } from ".";
 import { createContext } from "../utils/context";
-import { XmcpParsedConfig } from "./parse-xmcp-config";
+import { XmcpConfigOuputSchema } from "./config";
 
 interface CompilerContext {
   /** The mode of the compiler. */
@@ -17,7 +17,7 @@ interface CompilerContext {
   /** Whether the middleware is enabled. */
   hasMiddleware: boolean;
   /** The parsed config. */
-  xmcpConfig?: XmcpParsedConfig;
+  xmcpConfig?: XmcpConfigOuputSchema;
 }
 
 export const compilerContext = createContext<CompilerContext>({

--- a/packages/xmcp/src/compiler/config/constants.ts
+++ b/packages/xmcp/src/compiler/config/constants.ts
@@ -1,30 +1,11 @@
-import {
-  CorsConfig,
-  OauthConfig,
-  AdapterConfig,
-  ExperimentalConfig,
-  PathsConfig,
-} from ".";
-
-/**
- * Default values for the HTTP server
- */
-
-export const DEFAULT_HTTP_PORT = 3002;
-export const DEFAULT_HTTP_HOST = "127.0.0.1";
-export const DEFAULT_HTTP_BODY_SIZE_LIMIT = 1024 * 1024 * 10; // 10MB
-export const DEFAULT_HTTP_ENDPOINT = "/mcp";
-export const DEFAULT_HTTP_STATELESS = true;
-
-/**
- * Default values for the tools directory
- */
-export const DEFAULT_TOOLS_DIR = "src/tools";
+// ------------------------------------------------------------
+// Constants
+// ------------------------------------------------------------
 
 /**
  * Default values for CORS config
  */
-export const DEFAULT_CORS_CONFIG: CorsConfig = {
+export const DEFAULT_CORS_CONFIG = {
   origin: "*",
   methods: ["GET", "POST"],
   allowedHeaders: [
@@ -34,24 +15,25 @@ export const DEFAULT_CORS_CONFIG: CorsConfig = {
     "mcp-protocol-version",
   ],
   exposedHeaders: ["Content-Type", "Authorization", "mcp-session-id"],
-  credentials: true,
-  maxAge: 600,
+  credentials: false,
+  maxAge: 86400,
 };
 
 /**
- * Default values for Oauth config
+ * Default values for the HTTP transport
  */
-export const DEFAULT_OAUTH_CONFIG: OauthConfig = {
-  endpoints: {
-    authorizationUrl: "https://example.com/oauth2/authorize",
-    tokenUrl: "https://example.com/oauth2/token",
-    registerUrl: "https://example.com/oauth2/register",
-  },
-  issuerUrl: "https://example.com",
-  baseUrl: "https://example.com",
-  serviceDocumentationUrl: "https://example.com/oauth2/service-documentation",
-  pathPrefix: "/oauth2",
-  defaultScopes: ["openid", "profile", "email"],
+export const DEFAULT_HTTP_CONFIG = {
+  port: 3002,
+  host: "127.0.0.1",
+  bodySizeLimit: 1024 * 1024 * 10, // 10MB
+  debug: false,
+  endpoint: "/mcp",
+  cors: DEFAULT_CORS_CONFIG,
 };
 
-/** */
+/**
+ * Default values for the tools directory
+ */
+export const DEFAULT_PATHS_CONFIG = {
+  tools: "src/tools",
+};

--- a/packages/xmcp/src/compiler/config/constants.ts
+++ b/packages/xmcp/src/compiler/config/constants.ts
@@ -1,0 +1,57 @@
+import {
+  CorsConfig,
+  OauthConfig,
+  AdapterConfig,
+  ExperimentalConfig,
+  PathsConfig,
+} from ".";
+
+/**
+ * Default values for the HTTP server
+ */
+
+export const DEFAULT_HTTP_PORT = 3002;
+export const DEFAULT_HTTP_HOST = "127.0.0.1";
+export const DEFAULT_HTTP_BODY_SIZE_LIMIT = 1024 * 1024 * 10; // 10MB
+export const DEFAULT_HTTP_ENDPOINT = "/mcp";
+export const DEFAULT_HTTP_STATELESS = true;
+
+/**
+ * Default values for the tools directory
+ */
+export const DEFAULT_TOOLS_DIR = "src/tools";
+
+/**
+ * Default values for CORS config
+ */
+export const DEFAULT_CORS_CONFIG: CorsConfig = {
+  origin: "*",
+  methods: ["GET", "POST"],
+  allowedHeaders: [
+    "Content-Type",
+    "Authorization",
+    "mcp-session-id",
+    "mcp-protocol-version",
+  ],
+  exposedHeaders: ["Content-Type", "Authorization", "mcp-session-id"],
+  credentials: true,
+  maxAge: 600,
+};
+
+/**
+ * Default values for Oauth config
+ */
+export const DEFAULT_OAUTH_CONFIG: OauthConfig = {
+  endpoints: {
+    authorizationUrl: "https://example.com/oauth2/authorize",
+    tokenUrl: "https://example.com/oauth2/token",
+    registerUrl: "https://example.com/oauth2/register",
+  },
+  issuerUrl: "https://example.com",
+  baseUrl: "https://example.com",
+  serviceDocumentationUrl: "https://example.com/oauth2/service-documentation",
+  pathPrefix: "/oauth2",
+  defaultScopes: ["openid", "profile", "email"],
+};
+
+/** */

--- a/packages/xmcp/src/compiler/config/index.ts
+++ b/packages/xmcp/src/compiler/config/index.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+import {
+  DEFAULT_HTTP_BODY_SIZE_LIMIT,
+  DEFAULT_HTTP_ENDPOINT,
+  DEFAULT_HTTP_HOST,
+  DEFAULT_HTTP_PORT,
+  DEFAULT_TOOLS_DIR,
+} from "./constants";
+
+/**
+ * Cors config schema
+ */
+const corsConfigSchema = z.object({
+  origin: z.union([z.string(), z.array(z.string()), z.boolean()]).optional(),
+  methods: z.union([z.string(), z.array(z.string())]).optional(),
+  allowedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
+  exposedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
+  credentials: z.boolean().optional(),
+  maxAge: z.number().optional(),
+});
+
+export type CorsConfig = z.infer<typeof corsConfigSchema>;
+
+/**
+ * Oauth endpoints schema
+ */
+const oauthEndpointsSchema = z.object({
+  authorizationUrl: z.string(),
+  tokenUrl: z.string(),
+  revocationUrl: z.string().optional(),
+  userInfoUrl: z.string().optional(),
+  registerUrl: z.string(),
+});
+
+export type OauthEndpoints = z.infer<typeof oauthEndpointsSchema>;
+
+/**
+ * Oauth config schema
+ */
+const oauthConfigSchema = z.object({
+  endpoints: oauthEndpointsSchema,
+  issuerUrl: z.string(),
+  baseUrl: z.string(),
+  serviceDocumentationUrl: z.string().optional(),
+  pathPrefix: z.string().default("/oauth2"),
+  defaultScopes: z.array(z.string()).default(["openid", "profile", "email"]),
+});
+
+export type OauthConfig = z.infer<typeof oauthConfigSchema>;
+
+/**
+ * Adapter config schema
+ */
+const adapterConfigSchema = z.enum(["express", "nextjs"]);
+
+export type AdapterConfig = z.infer<typeof adapterConfigSchema>;
+
+/**
+ * Experimental features schema
+ */
+const experimentalConfigSchema = z.object({
+  oauth: oauthConfigSchema.optional(),
+  adapter: adapterConfigSchema.optional(),
+});
+
+export type ExperimentalConfig = z.infer<typeof experimentalConfigSchema>;
+
+/**
+ * Paths config schema
+ */
+const pathsConfigSchema = z.object({
+  tools: z.string().default(DEFAULT_TOOLS_DIR),
+  // TO DO add resources prompts etc
+});
+
+export type PathsConfig = z.infer<typeof pathsConfigSchema>;
+
+/**
+ * xmcp Config schema
+ */
+export const configSchema = z.object({
+  stdio: z.boolean().optional(),
+  http: z
+    .union([
+      z.boolean(),
+      z.object({
+        port: z.number().default(DEFAULT_HTTP_PORT),
+        host: z.string().default(DEFAULT_HTTP_HOST),
+        bodySizeLimit: z.number().default(DEFAULT_HTTP_BODY_SIZE_LIMIT),
+        debug: z.boolean().default(false),
+        endpoint: z.string().default(DEFAULT_HTTP_ENDPOINT),
+        cors: corsConfigSchema.optional(),
+      }),
+    ])
+    .optional(),
+  experimental: experimentalConfigSchema.optional(),
+  paths: pathsConfigSchema.optional().default({
+    tools: DEFAULT_TOOLS_DIR,
+  }),
+  webpack: z.function().args(z.any()).returns(z.any()).optional(),
+});
+
+export type ConfigSchema = z.infer<typeof configSchema>;
+
+export type InputSchema = z.input<typeof configSchema>;
+export type OutputSchema = z.output<typeof configSchema>;

--- a/packages/xmcp/src/compiler/config/index.ts
+++ b/packages/xmcp/src/compiler/config/index.ts
@@ -1,103 +1,21 @@
 import { z } from "zod";
 import {
-  DEFAULT_HTTP_BODY_SIZE_LIMIT,
-  DEFAULT_HTTP_ENDPOINT,
-  DEFAULT_HTTP_HOST,
-  DEFAULT_HTTP_PORT,
-  DEFAULT_TOOLS_DIR,
-} from "./constants";
-
-/**
- * Cors config schema
- */
-const corsConfigSchema = z.object({
-  origin: z.union([z.string(), z.array(z.string()), z.boolean()]).optional(),
-  methods: z.union([z.string(), z.array(z.string())]).optional(),
-  allowedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
-  exposedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
-  credentials: z.boolean().optional(),
-  maxAge: z.number().optional(),
-});
-
-export type CorsConfig = z.infer<typeof corsConfigSchema>;
-
-/**
- * Oauth endpoints schema
- */
-const oauthEndpointsSchema = z.object({
-  authorizationUrl: z.string(),
-  tokenUrl: z.string(),
-  revocationUrl: z.string().optional(),
-  userInfoUrl: z.string().optional(),
-  registerUrl: z.string(),
-});
-
-export type OauthEndpoints = z.infer<typeof oauthEndpointsSchema>;
-
-/**
- * Oauth config schema
- */
-const oauthConfigSchema = z.object({
-  endpoints: oauthEndpointsSchema,
-  issuerUrl: z.string(),
-  baseUrl: z.string(),
-  serviceDocumentationUrl: z.string().optional(),
-  pathPrefix: z.string().default("/oauth2"),
-  defaultScopes: z.array(z.string()).default(["openid", "profile", "email"]),
-});
-
-export type OauthConfig = z.infer<typeof oauthConfigSchema>;
-
-/**
- * Adapter config schema
- */
-const adapterConfigSchema = z.enum(["express", "nextjs"]);
-
-export type AdapterConfig = z.infer<typeof adapterConfigSchema>;
-
-/**
- * Experimental features schema
- */
-const experimentalConfigSchema = z.object({
-  oauth: oauthConfigSchema.optional(),
-  adapter: adapterConfigSchema.optional(),
-});
-
-export type ExperimentalConfig = z.infer<typeof experimentalConfigSchema>;
-
-/**
- * Paths config schema
- */
-const pathsConfigSchema = z.object({
-  tools: z.string().default(DEFAULT_TOOLS_DIR),
-  // TO DO add resources prompts etc
-});
-
-export type PathsConfig = z.infer<typeof pathsConfigSchema>;
+  stdioTransportConfigSchema,
+  httpTransportConfigSchema,
+  experimentalConfigSchema,
+  pathsConfigSchema,
+  webpackConfigSchema,
+} from "./schemas";
 
 /**
  * xmcp Config schema
  */
 export const configSchema = z.object({
-  stdio: z.boolean().optional(),
-  http: z
-    .union([
-      z.boolean(),
-      z.object({
-        port: z.number().default(DEFAULT_HTTP_PORT),
-        host: z.string().default(DEFAULT_HTTP_HOST),
-        bodySizeLimit: z.number().default(DEFAULT_HTTP_BODY_SIZE_LIMIT),
-        debug: z.boolean().default(false),
-        endpoint: z.string().default(DEFAULT_HTTP_ENDPOINT),
-        cors: corsConfigSchema.optional(),
-      }),
-    ])
-    .optional(),
+  stdio: stdioTransportConfigSchema.optional(),
+  http: httpTransportConfigSchema.optional(),
   experimental: experimentalConfigSchema.optional(),
-  paths: pathsConfigSchema.optional().default({
-    tools: DEFAULT_TOOLS_DIR,
-  }),
-  webpack: z.function().args(z.any()).returns(z.any()).optional(),
+  paths: pathsConfigSchema.optional(),
+  webpack: webpackConfigSchema.optional(),
 });
 
 export type ConfigSchema = z.infer<typeof configSchema>;

--- a/packages/xmcp/src/compiler/config/index.ts
+++ b/packages/xmcp/src/compiler/config/index.ts
@@ -6,6 +6,7 @@ import {
   pathsConfigSchema,
   webpackConfigSchema,
 } from "./schemas";
+import { Configuration } from "webpack";
 
 /**
  * xmcp Config schema
@@ -18,7 +19,16 @@ export const configSchema = z.object({
   webpack: webpackConfigSchema.optional(),
 });
 
-export type ConfigSchema = z.infer<typeof configSchema>;
+type WebpackConfig = { webpack?: (config: Configuration) => Configuration };
 
-export type InputSchema = z.input<typeof configSchema>;
-export type OutputSchema = z.output<typeof configSchema>;
+export type XmcpConfigInputSchema = Omit<
+  z.input<typeof configSchema>,
+  "webpack"
+> &
+  WebpackConfig;
+
+export type XmcpConfigOuputSchema = Omit<
+  z.output<typeof configSchema>,
+  "webpack"
+> &
+  WebpackConfig;

--- a/packages/xmcp/src/compiler/config/injection.ts
+++ b/packages/xmcp/src/compiler/config/injection.ts
@@ -6,7 +6,6 @@ import {
 } from "./utils";
 import { HttpTransportConfig } from "./schemas/transport/http";
 
-// perhaps type the variables?
 export function injectHttpVariables(
   httpConfig: HttpTransportConfig | boolean,
   mode: string
@@ -15,12 +14,14 @@ export function injectHttpVariables(
   if (!resolvedConfig) return {};
 
   return {
-    HTTP_PORT: resolvedConfig.port,
-    HTTP_HOST: resolvedConfig.host,
-    HTTP_BODY_SIZE_LIMIT: JSON.stringify(resolvedConfig.bodySizeLimit),
-    HTTP_ENDPOINT: JSON.stringify(resolvedConfig.endpoint),
-    HTTP_STATELESS: true, // eventually should be configurable for statfeul
-    HTTP_DEBUG: mode === "development",
+    HTTP_CONFIG: JSON.stringify({
+      port: resolvedConfig.port,
+      host: resolvedConfig.host,
+      bodySizeLimit: resolvedConfig.bodySizeLimit,
+      endpoint: resolvedConfig.endpoint,
+      stateless: true,
+      debug: mode === "development",
+    }),
   };
 }
 
@@ -30,12 +31,14 @@ export function injectCorsVariables(httpConfig: HttpTransportConfig | null) {
   const corsConfig = getResolvedCorsConfig(httpConfig);
 
   return {
-    HTTP_CORS_ORIGIN: JSON.stringify(corsConfig.origin ?? ""),
-    HTTP_CORS_METHODS: JSON.stringify(corsConfig.methods ?? ""),
-    HTTP_CORS_ALLOWED_HEADERS: JSON.stringify(corsConfig.allowedHeaders ?? ""),
-    HTTP_CORS_EXPOSED_HEADERS: JSON.stringify(corsConfig.exposedHeaders ?? ""),
-    HTTP_CORS_CREDENTIALS: corsConfig.credentials ?? false,
-    HTTP_CORS_MAX_AGE: corsConfig.maxAge ?? 0,
+    HTTP_CORS_CONFIG: JSON.stringify({
+      origin: corsConfig.origin ?? "",
+      methods: corsConfig.methods ?? "",
+      allowedHeaders: corsConfig.allowedHeaders ?? "",
+      exposedHeaders: corsConfig.exposedHeaders ?? "",
+      credentials: corsConfig.credentials ?? false,
+      maxAge: corsConfig.maxAge ?? 0,
+    }),
   };
 }
 

--- a/packages/xmcp/src/compiler/config/injection.ts
+++ b/packages/xmcp/src/compiler/config/injection.ts
@@ -1,0 +1,54 @@
+import {
+  getResolvedHttpConfig,
+  getResolvedCorsConfig,
+  getResolvedPathsConfig,
+  getResolvedOAuthConfig,
+} from "./utils";
+import { HttpTransportConfig } from "./schemas/transport/http";
+
+// perhaps type the variables?
+export function injectHttpVariables(
+  httpConfig: HttpTransportConfig | boolean,
+  mode: string
+) {
+  const resolvedConfig = getResolvedHttpConfig(httpConfig);
+  if (!resolvedConfig) return {};
+
+  return {
+    HTTP_PORT: resolvedConfig.port,
+    HTTP_HOST: resolvedConfig.host,
+    HTTP_BODY_SIZE_LIMIT: JSON.stringify(resolvedConfig.bodySizeLimit),
+    HTTP_ENDPOINT: JSON.stringify(resolvedConfig.endpoint),
+    HTTP_STATELESS: true, // eventually should be configurable for statfeul
+    HTTP_DEBUG: mode === "development",
+  };
+}
+
+export function injectCorsVariables(httpConfig: HttpTransportConfig | null) {
+  const corsConfig = getResolvedCorsConfig(httpConfig);
+
+  return {
+    HTTP_CORS_ORIGIN: JSON.stringify(corsConfig.origin ?? ""),
+    HTTP_CORS_METHODS: JSON.stringify(corsConfig.methods ?? ""),
+    HTTP_CORS_ALLOWED_HEADERS: JSON.stringify(corsConfig.allowedHeaders ?? ""),
+    HTTP_CORS_EXPOSED_HEADERS: JSON.stringify(corsConfig.exposedHeaders ?? ""),
+    HTTP_CORS_CREDENTIALS: corsConfig.credentials ?? false,
+    HTTP_CORS_MAX_AGE: corsConfig.maxAge ?? 0,
+  };
+}
+
+export function injectOAuthVariables(userConfig: any) {
+  const oauthConfig = getResolvedOAuthConfig(userConfig);
+
+  return {
+    OAUTH_CONFIG: JSON.stringify(oauthConfig),
+  };
+}
+
+export function injectPathsVariables(userConfig: any) {
+  const pathsConfig = getResolvedPathsConfig(userConfig);
+
+  return {
+    TOOLS_PATH: JSON.stringify(pathsConfig.tools),
+  };
+}

--- a/packages/xmcp/src/compiler/config/injection.ts
+++ b/packages/xmcp/src/compiler/config/injection.ts
@@ -24,6 +24,8 @@ export function injectHttpVariables(
   };
 }
 
+export type HttpVariables = ReturnType<typeof injectHttpVariables>;
+
 export function injectCorsVariables(httpConfig: HttpTransportConfig | null) {
   const corsConfig = getResolvedCorsConfig(httpConfig);
 
@@ -37,6 +39,8 @@ export function injectCorsVariables(httpConfig: HttpTransportConfig | null) {
   };
 }
 
+export type CorsVariables = ReturnType<typeof injectCorsVariables>;
+
 export function injectOAuthVariables(userConfig: any) {
   const oauthConfig = getResolvedOAuthConfig(userConfig);
 
@@ -45,6 +49,8 @@ export function injectOAuthVariables(userConfig: any) {
   };
 }
 
+export type OAuthVariables = ReturnType<typeof injectOAuthVariables>;
+
 export function injectPathsVariables(userConfig: any) {
   const pathsConfig = getResolvedPathsConfig(userConfig);
 
@@ -52,3 +58,11 @@ export function injectPathsVariables(userConfig: any) {
     TOOLS_PATH: JSON.stringify(pathsConfig.tools),
   };
 }
+
+export type PathsVariables = ReturnType<typeof injectPathsVariables>;
+
+export type InjectedVariables =
+  | HttpVariables
+  | CorsVariables
+  | OAuthVariables
+  | PathsVariables;

--- a/packages/xmcp/src/compiler/config/schemas/experimental/index.ts
+++ b/packages/xmcp/src/compiler/config/schemas/experimental/index.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { oauthConfigSchema } from "./oauth";
+
+// ------------------------------------------------------------
+// Adapter config schema (perhaps a separate file but it's small yet)
+// ------------------------------------------------------------
+export const adapterConfigSchema = z.enum(["express", "nextjs"]);
+
+export type AdapterConfig = z.infer<typeof adapterConfigSchema>;
+
+// ------------------------------------------------------------
+// Experimental features schema
+// ------------------------------------------------------------
+export const experimentalConfigSchema = z.object({
+  oauth: oauthConfigSchema.optional(),
+  adapter: adapterConfigSchema.optional(),
+});
+
+export type ExperimentalConfig = z.infer<typeof experimentalConfigSchema>;

--- a/packages/xmcp/src/compiler/config/schemas/experimental/oauth.ts
+++ b/packages/xmcp/src/compiler/config/schemas/experimental/oauth.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+// ------------------------------------------------------------
+// OAuth endpoints schema
+// ------------------------------------------------------------
+export const oauthEndpointsSchema = z.object({
+  authorizationUrl: z.string(),
+  tokenUrl: z.string(),
+  revocationUrl: z.string().optional(),
+  userInfoUrl: z.string().optional(),
+  registerUrl: z.string(),
+});
+
+export type OauthEndpoints = z.infer<typeof oauthEndpointsSchema>;
+
+// ------------------------------------------------------------
+// OAuth config schema
+// ------------------------------------------------------------
+export const oauthConfigSchema = z.object({
+  endpoints: oauthEndpointsSchema,
+  issuerUrl: z.string(),
+  baseUrl: z.string(),
+  serviceDocumentationUrl: z.string().optional(),
+  pathPrefix: z.string().default("/oauth2"),
+  defaultScopes: z.array(z.string()).default(["openid", "profile", "email"]),
+});
+
+export type OAuthConfig = z.infer<typeof oauthConfigSchema>;

--- a/packages/xmcp/src/compiler/config/schemas/index.ts
+++ b/packages/xmcp/src/compiler/config/schemas/index.ts
@@ -1,0 +1,18 @@
+// re export
+export {
+  httpTransportConfigSchema,
+  corsConfigSchema,
+  type HttpTransportConfig,
+  type CorsConfig,
+} from "./transport/http";
+export {
+  stdioTransportConfigSchema,
+  type StdioTransportConfig,
+} from "./transport/stdio";
+export { oauthConfigSchema, type OAuthConfig } from "./experimental/oauth";
+export {
+  experimentalConfigSchema,
+  type ExperimentalConfig,
+} from "./experimental";
+export { pathsConfigSchema, type PathsConfig } from "./paths";
+export { webpackConfigSchema, type WebpackConfig } from "./webpack";

--- a/packages/xmcp/src/compiler/config/schemas/paths.ts
+++ b/packages/xmcp/src/compiler/config/schemas/paths.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { DEFAULT_PATHS_CONFIG } from "../constants";
+
+// ------------------------------------------------------------
+// Paths config schema
+// ------------------------------------------------------------
+export const pathsConfigSchema = z.object({
+  tools: z.string().default(DEFAULT_PATHS_CONFIG.tools),
+  // TO DO add resources prompts etc
+});
+
+export type PathsConfig = z.infer<typeof pathsConfigSchema>;

--- a/packages/xmcp/src/compiler/config/schemas/transport/http.ts
+++ b/packages/xmcp/src/compiler/config/schemas/transport/http.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { DEFAULT_HTTP_CONFIG } from "../../constants";
+
+// ------------------------------------------------------------
+// Cors config schema
+// ------------------------------------------------------------
+export const corsConfigSchema = z.object({
+  origin: z.union([z.string(), z.array(z.string()), z.boolean()]).optional(),
+  methods: z.union([z.string(), z.array(z.string())]).optional(),
+  allowedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
+  exposedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
+  credentials: z.boolean().optional(),
+  maxAge: z.number().optional(),
+});
+
+export type CorsConfig = z.infer<typeof corsConfigSchema>;
+
+// ------------------------------------------------------------
+// HTTP Transport config schema
+// ------------------------------------------------------------
+export const httpTransportConfigSchema = z.union([
+  z.boolean(),
+  z
+    .object({
+      port: z.number().optional(),
+      host: z.string().optional(),
+      bodySizeLimit: z.number().optional(),
+      debug: z.boolean().optional(),
+      endpoint: z.string().optional(),
+      cors: corsConfigSchema.optional(),
+    })
+    .default(DEFAULT_HTTP_CONFIG)
+    .optional(),
+]);
+
+export type HttpTransportConfig = z.infer<typeof httpTransportConfigSchema>;

--- a/packages/xmcp/src/compiler/config/schemas/transport/stdio.ts
+++ b/packages/xmcp/src/compiler/config/schemas/transport/stdio.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+// ------------------------------------------------------------
+// stdio transport config schema
+// ------------------------------------------------------------
+export const stdioTransportConfigSchema = z.boolean().optional();
+
+export type StdioTransportConfig = z.infer<typeof stdioTransportConfigSchema>;

--- a/packages/xmcp/src/compiler/config/schemas/webpack.ts
+++ b/packages/xmcp/src/compiler/config/schemas/webpack.ts
@@ -1,0 +1,12 @@
+import z from "zod";
+
+// ------------------------------------------------------------
+// Webpack config schema
+// ------------------------------------------------------------
+export const webpackConfigSchema = z
+  .function()
+  .args(z.any())
+  .returns(z.any())
+  .optional();
+
+export type WebpackConfig = z.infer<typeof webpackConfigSchema>;

--- a/packages/xmcp/src/compiler/config/types.ts
+++ b/packages/xmcp/src/compiler/config/types.ts
@@ -1,0 +1,10 @@
+// Re-export all types from schemas
+export type {
+  HttpTransportConfig,
+  StdioTransportConfig,
+  CorsConfig,
+  OAuthConfig,
+  ExperimentalConfig,
+  PathsConfig,
+  WebpackConfig,
+} from "./schemas";

--- a/packages/xmcp/src/compiler/config/utils.ts
+++ b/packages/xmcp/src/compiler/config/utils.ts
@@ -1,0 +1,36 @@
+import {
+  HttpTransportConfig,
+  CorsConfig,
+  PathsConfig,
+  OAuthConfig,
+} from "./schemas";
+import { DEFAULT_HTTP_CONFIG, DEFAULT_PATHS_CONFIG } from "./constants";
+
+export function getResolvedHttpConfig(
+  userConfig: HttpTransportConfig | undefined
+) {
+  if (typeof userConfig === "boolean") {
+    return userConfig ? DEFAULT_HTTP_CONFIG : null;
+  }
+  if (typeof userConfig === "object") {
+    return { ...DEFAULT_HTTP_CONFIG, ...userConfig };
+  }
+  return null;
+}
+
+export function getResolvedCorsConfig(
+  httpConfig: HttpTransportConfig | null
+): CorsConfig {
+  if (typeof httpConfig === "object" && httpConfig?.cors) {
+    return { ...DEFAULT_HTTP_CONFIG.cors, ...httpConfig.cors };
+  }
+  return DEFAULT_HTTP_CONFIG.cors;
+}
+
+export function getResolvedPathsConfig(userConfig: any): PathsConfig {
+  return { ...DEFAULT_PATHS_CONFIG, ...userConfig?.paths };
+}
+
+export function getResolvedOAuthConfig(userConfig: any): OAuthConfig | null {
+  return userConfig?.experimental?.oauth || null;
+}

--- a/packages/xmcp/src/compiler/get-webpack-config/get-entries.ts
+++ b/packages/xmcp/src/compiler/get-webpack-config/get-entries.ts
@@ -1,10 +1,10 @@
 import { runtimeFolderPath } from "@/utils/constants";
-import { XmcpParsedConfig } from "@/compiler/parse-xmcp-config";
+import { XmcpConfigOuputSchema } from "@/compiler/config";
 import path from "path";
 
 /** Get what packages are gonna be built by xmcp */
 export function getEntries(
-  xmcpConfig: XmcpParsedConfig
+  xmcpConfig: XmcpConfigOuputSchema
 ): Record<string, string> {
   const entries: Record<string, string> = {};
   if (xmcpConfig.stdio) {

--- a/packages/xmcp/src/compiler/get-webpack-config/get-injected-variables.ts
+++ b/packages/xmcp/src/compiler/get-webpack-config/get-injected-variables.ts
@@ -1,6 +1,4 @@
-// TODO create a shaded utility to type injected variables shaded between the runtime and the xmcp compiler
-
-import { XmcpParsedConfig } from "@/compiler/parse-xmcp-config";
+import { XmcpConfigOuputSchema } from "@/compiler/config";
 import { compilerContext } from "../compiler-context";
 import {
   injectCorsVariables,
@@ -15,9 +13,8 @@ import {
  *
  * This utility will define those variables based on the user's config.
  */
-
 export function getInjectedVariables(
-  xmcpConfig: XmcpParsedConfig
+  xmcpConfig: XmcpConfigOuputSchema
 ): InjectedVariables {
   const { mode } = compilerContext.getContext();
 
@@ -33,59 +30,3 @@ export function getInjectedVariables(
     ...pathsVariables,
   };
 }
-
-/*
-export function getInjectedVariables(xmcpConfig: XmcpParsedConfig) {
-  const { mode } = compilerContext.getContext();
-
-  const definedVariables: Record<string, string | number | boolean> = {};
-
-  if (xmcpConfig["http"]) {
-    // define variables
-    definedVariables.HTTP_DEBUG = mode === "development";
-    let cors: CorsConfig = {};
-    if (typeof xmcpConfig["http"] === "object") {
-      definedVariables.HTTP_PORT = xmcpConfig["http"].port;
-      definedVariables.HTTP_BODY_SIZE_LIMIT = JSON.stringify(
-        xmcpConfig["http"].bodySizeLimit
-      );
-      definedVariables.HTTP_ENDPOINT = JSON.stringify(
-        xmcpConfig["http"].endpoint
-      );
-      definedVariables.HTTP_STATELESS = DEFAULT_HTTP_STATELESS;
-      cors = xmcpConfig["http"].cors || {};
-    } else {
-      // http config is boolean
-      definedVariables.HTTP_PORT = DEFAULT_HTTP_PORT;
-      definedVariables.HTTP_BODY_SIZE_LIMIT = JSON.stringify(
-        DEFAULT_HTTP_BODY_SIZE_LIMIT
-      );
-      definedVariables.HTTP_ENDPOINT = JSON.stringify(DEFAULT_HTTP_ENDPOINT);
-      definedVariables.HTTP_STATELESS = DEFAULT_HTTP_STATELESS;
-      cors = {};
-    }
-    // inject cors
-    definedVariables.HTTP_CORS_ORIGIN = JSON.stringify(cors.origin ?? "");
-    definedVariables.HTTP_CORS_METHODS = JSON.stringify(cors.methods ?? "");
-    definedVariables.HTTP_CORS_ALLOWED_HEADERS = JSON.stringify(
-      cors.allowedHeaders ?? ""
-    );
-    definedVariables.HTTP_CORS_EXPOSED_HEADERS = JSON.stringify(
-      cors.exposedHeaders ?? ""
-    );
-    definedVariables.HTTP_CORS_CREDENTIALS =
-      typeof cors.credentials === "boolean" ? cors.credentials : false;
-    definedVariables.HTTP_CORS_MAX_AGE =
-      typeof cors.maxAge === "number" ? cors.maxAge : 0;
-
-    // inject oauth config
-    definedVariables.OAUTH_CONFIG = JSON.stringify(
-      xmcpConfig.experimental?.oauth || null
-    );
-  }
-
-  definedVariables.TOOLS_PATH = JSON.stringify(xmcpConfig.paths?.tools);
-
-  return definedVariables;
-}
-*/

--- a/packages/xmcp/src/compiler/get-webpack-config/get-injected-variables.ts
+++ b/packages/xmcp/src/compiler/get-webpack-config/get-injected-variables.ts
@@ -1,29 +1,37 @@
 // TODO create a shaded utility to type injected variables shaded between the runtime and the xmcp compiler
 
-import {
-  DEFAULT_HTTP_BODY_SIZE_LIMIT,
-  DEFAULT_HTTP_ENDPOINT,
-  DEFAULT_HTTP_PORT,
-  DEFAULT_HTTP_STATELESS,
-  XmcpParsedConfig,
-} from "@/compiler/parse-xmcp-config";
+import { XmcpParsedConfig } from "@/compiler/parse-xmcp-config";
 import { compilerContext } from "../compiler-context";
-
-// Add this type for local use
-type CorsConfig = {
-  origin?: string | string[] | boolean;
-  methods?: string | string[];
-  allowedHeaders?: string | string[];
-  exposedHeaders?: string | string[];
-  credentials?: boolean;
-  maxAge?: number;
-};
+import {
+  injectCorsVariables,
+  injectHttpVariables,
+  injectOAuthVariables,
+  injectPathsVariables,
+} from "../config/injection";
 
 /**
  * The XMCP runtime uses variables that are not defined by default.
  *
  * This utility will define those variables based on the user's config.
  */
+
+export function getInjectedVariables(xmcpConfig: XmcpParsedConfig) {
+  const { mode } = compilerContext.getContext();
+
+  const httpVariables = injectHttpVariables(xmcpConfig.http, mode);
+  const corsVariables = injectCorsVariables(xmcpConfig.http);
+  const oauthVariables = injectOAuthVariables(xmcpConfig);
+  const pathsVariables = injectPathsVariables(xmcpConfig);
+
+  return {
+    ...httpVariables,
+    ...corsVariables,
+    ...oauthVariables,
+    ...pathsVariables,
+  };
+}
+
+/*
 export function getInjectedVariables(xmcpConfig: XmcpParsedConfig) {
   const { mode } = compilerContext.getContext();
 
@@ -77,3 +85,4 @@ export function getInjectedVariables(xmcpConfig: XmcpParsedConfig) {
 
   return definedVariables;
 }
+*/

--- a/packages/xmcp/src/compiler/get-webpack-config/get-injected-variables.ts
+++ b/packages/xmcp/src/compiler/get-webpack-config/get-injected-variables.ts
@@ -4,6 +4,7 @@ import { XmcpParsedConfig } from "@/compiler/parse-xmcp-config";
 import { compilerContext } from "../compiler-context";
 import {
   injectCorsVariables,
+  InjectedVariables,
   injectHttpVariables,
   injectOAuthVariables,
   injectPathsVariables,
@@ -15,7 +16,9 @@ import {
  * This utility will define those variables based on the user's config.
  */
 
-export function getInjectedVariables(xmcpConfig: XmcpParsedConfig) {
+export function getInjectedVariables(
+  xmcpConfig: XmcpParsedConfig
+): InjectedVariables {
   const { mode } = compilerContext.getContext();
 
   const httpVariables = injectHttpVariables(xmcpConfig.http, mode);

--- a/packages/xmcp/src/compiler/get-webpack-config/index.ts
+++ b/packages/xmcp/src/compiler/get-webpack-config/index.ts
@@ -7,7 +7,7 @@ import {
 import path from "path";
 import { distOutputPath, adapterOutputPath } from "@/utils/constants";
 import { compilerContext } from "@/compiler/compiler-context";
-import { XmcpParsedConfig } from "@/compiler/parse-xmcp-config";
+import { XmcpConfigOuputSchema } from "@/compiler/config";
 import { getEntries } from "./get-entries";
 import { getInjectedVariables } from "./get-injected-variables";
 import { resolveTsconfigPathsToAlias } from "./resolve-tsconfig-paths";
@@ -16,7 +16,9 @@ import { CreateTypeDefinitionPlugin, InjectRuntimePlugin } from "./plugins";
 import { getExternals } from "./get-externals";
 
 /** Creates the webpack configuration that xmcp will use to bundle the user's code */
-export function getWebpackConfig(xmcpConfig: XmcpParsedConfig): Configuration {
+export function getWebpackConfig(
+  xmcpConfig: XmcpConfigOuputSchema
+): Configuration {
   const processFolder = process.cwd();
   const { mode } = compilerContext.getContext();
 

--- a/packages/xmcp/src/compiler/get-webpack-config/plugins.ts
+++ b/packages/xmcp/src/compiler/get-webpack-config/plugins.ts
@@ -1,8 +1,4 @@
-import {
-  adapterOutputPath,
-  distOutputPath,
-  runtimeFolderPath,
-} from "@/utils/constants";
+import { adapterOutputPath, runtimeFolderPath } from "@/utils/constants";
 import fs from "fs-extra";
 import path from "path";
 import { Compiler } from "webpack";

--- a/packages/xmcp/src/compiler/get-webpack-config/plugins.ts
+++ b/packages/xmcp/src/compiler/get-webpack-config/plugins.ts
@@ -40,6 +40,8 @@ export class CreateTypeDefinitionPlugin {
         const xmcpConfig = getXmcpConfig();
 
         // Manually type the .xmcp/adapter/index.js file using a .xmcp/adapter/index.d.ts file
+
+        // TO DO add withAuth to the type definition & AuthConfig
         if (xmcpConfig.experimental?.adapter) {
           let typeDefinitionContent = "";
           if (xmcpConfig.experimental?.adapter == "nextjs") {

--- a/packages/xmcp/src/compiler/on-first-build.ts
+++ b/packages/xmcp/src/compiler/on-first-build.ts
@@ -1,10 +1,13 @@
 import { spawn } from "child_process";
 import { CompilerMode } from ".";
-import { XmcpInputConfig } from "./parse-xmcp-config";
 import { watchdog } from "../utils/spawn-process";
 import { greenCheck } from "../utils/cli-icons";
+import { XmcpConfigOuputSchema } from "./config";
 
-export function onFirstBuild(mode: CompilerMode, xmcpConfig: XmcpInputConfig) {
+export function onFirstBuild(
+  mode: CompilerMode,
+  xmcpConfig: XmcpConfigOuputSchema
+) {
   if (mode === "development" && false) {
     // disable inspector for now
     console.log("🔍 Starting inspector...");

--- a/packages/xmcp/src/compiler/parse-xmcp-config.ts
+++ b/packages/xmcp/src/compiler/parse-xmcp-config.ts
@@ -4,7 +4,7 @@ import { webpack, type Configuration } from "webpack";
 import { createFsFromVolume, Volume } from "memfs";
 import { compilerContext } from "./compiler-context";
 import { configSchema, type InputSchema, type OutputSchema } from "./config";
-import { DEFAULT_TOOLS_DIR } from "./config/constants";
+import { DEFAULT_PATHS_CONFIG } from "./config/constants";
 
 /** Config type for the user to provide */
 export type XmcpInputConfig = Omit<InputSchema, "webpack"> & {
@@ -71,9 +71,7 @@ export async function readConfig(): Promise<XmcpParsedConfig> {
   return {
     stdio: true,
     http: true,
-    paths: {
-      tools: DEFAULT_TOOLS_DIR,
-    },
+    paths: DEFAULT_PATHS_CONFIG,
   } satisfies XmcpInputConfig;
 }
 

--- a/packages/xmcp/src/compiler/parse-xmcp-config.ts
+++ b/packages/xmcp/src/compiler/parse-xmcp-config.ts
@@ -3,20 +3,14 @@ import path from "path";
 import { webpack, type Configuration } from "webpack";
 import { createFsFromVolume, Volume } from "memfs";
 import { compilerContext } from "./compiler-context";
-import { configSchema, type InputSchema, type OutputSchema } from "./config";
+import {
+  configSchema,
+  XmcpConfigInputSchema,
+  type XmcpConfigOuputSchema,
+} from "./config";
 import { DEFAULT_PATHS_CONFIG } from "./config/constants";
 
-/** Config type for the user to provide */
-export type XmcpInputConfig = Omit<InputSchema, "webpack"> & {
-  webpack?: (config: Configuration) => Configuration;
-};
-
-/** Config with defaults applied */
-export type XmcpParsedConfig = Omit<OutputSchema, "webpack"> & {
-  webpack?: (config: Configuration) => Configuration;
-};
-
-function validateConfig(config: unknown): XmcpParsedConfig {
+function validateConfig(config: unknown): XmcpConfigOuputSchema {
   return configSchema.parse(config);
 }
 
@@ -37,7 +31,7 @@ const configPaths = {
 /**
  * Parse and validate xmcp config file
  */
-export async function getConfig(): Promise<XmcpParsedConfig> {
+export async function getConfig(): Promise<XmcpConfigOuputSchema> {
   const config = await readConfig();
   const { platforms } = compilerContext.getContext();
   if (platforms.vercel) {
@@ -50,7 +44,7 @@ export async function getConfig(): Promise<XmcpParsedConfig> {
 /**
  * Read config from file or return default
  */
-export async function readConfig(): Promise<XmcpParsedConfig> {
+export async function readConfig(): Promise<XmcpConfigOuputSchema> {
   // Simple json config
   const jsonFile = readConfigFile(configPaths.json);
   if (jsonFile) {
@@ -72,14 +66,14 @@ export async function readConfig(): Promise<XmcpParsedConfig> {
     stdio: true,
     http: true,
     paths: DEFAULT_PATHS_CONFIG,
-  } satisfies XmcpInputConfig;
+  } satisfies XmcpConfigInputSchema;
 }
 
 /**
  * If the user is using a typescript config file,
  * we need to bundle it, run it and return its copiled code
  * */
-async function compileConfig(): Promise<XmcpParsedConfig> {
+async function compileConfig(): Promise<XmcpConfigOuputSchema> {
   const configPath = path.resolve(process.cwd(), configPaths.ts);
 
   // Create memory filesystem

--- a/packages/xmcp/src/compiler/parse-xmcp-config.ts
+++ b/packages/xmcp/src/compiler/parse-xmcp-config.ts
@@ -1,85 +1,10 @@
 import fs from "fs";
 import path from "path";
-import { z } from "zod";
 import { webpack, type Configuration } from "webpack";
 import { createFsFromVolume, Volume } from "memfs";
 import { compilerContext } from "./compiler-context";
-
-export const DEFAULT_HTTP_PORT = 3002;
-export const DEFAULT_HTTP_BODY_SIZE_LIMIT = 1024 * 1024 * 10; // 10MB
-export const DEFAULT_HTTP_ENDPOINT = "/mcp";
-export const DEFAULT_HTTP_STATELESS = true;
-
-export const DEFAULT_TOOLS_DIR = "src/tools";
-
-// cors config schema
-const corsConfigSchema = z.object({
-  origin: z.union([z.string(), z.array(z.string()), z.boolean()]).optional(),
-  methods: z.union([z.string(), z.array(z.string())]).optional(),
-  allowedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
-  exposedHeaders: z.union([z.string(), z.array(z.string())]).optional(),
-  credentials: z.boolean().optional(),
-  maxAge: z.number().optional(),
-});
-
-// oauth endpoints schema
-const oauthEndpointsSchema = z.object({
-  authorizationUrl: z.string(),
-  tokenUrl: z.string(),
-  revocationUrl: z.string().optional(),
-  userInfoUrl: z.string().optional(),
-  registerUrl: z.string(),
-});
-
-// oauth config schema
-const oauthConfigSchema = z.object({
-  endpoints: oauthEndpointsSchema,
-  issuerUrl: z.string(),
-  baseUrl: z.string(),
-  serviceDocumentationUrl: z.string().optional(),
-  pathPrefix: z.string().default("/oauth2"),
-  defaultScopes: z.array(z.string()).default(["openid", "profile", "email"]),
-});
-
-// adapter config schema
-const adapterConfigSchema = z.enum(["express", "nextjs"]);
-
-// experimental features schema
-const experimentalConfigSchema = z.object({
-  oauth: oauthConfigSchema.optional(),
-  adapter: adapterConfigSchema.optional(),
-});
-
-// paths config
-const pathsConfigSchema = z.object({
-  tools: z.string().default(DEFAULT_TOOLS_DIR),
-  // to do add resources prompts etc
-});
-
-// TODO extract all this config and schemas to a separate file
-const configSchema = z.object({
-  stdio: z.boolean().optional(),
-  http: z
-    .union([
-      z.boolean(),
-      z.object({
-        port: z.number().default(DEFAULT_HTTP_PORT),
-        bodySizeLimit: z.number().default(DEFAULT_HTTP_BODY_SIZE_LIMIT),
-        debug: z.boolean().default(false),
-        endpoint: z.string().default(DEFAULT_HTTP_ENDPOINT),
-        cors: corsConfigSchema.optional(),
-      }),
-    ])
-    .optional(),
-  experimental: experimentalConfigSchema.optional(),
-  paths: pathsConfigSchema.optional().default({
-    tools: DEFAULT_TOOLS_DIR,
-  }),
-  webpack: z.function().args(z.any()).returns(z.any()).optional(),
-});
-
-type InputSchema = z.input<typeof configSchema>;
-type OutputSchema = z.output<typeof configSchema>;
+import { configSchema, type InputSchema, type OutputSchema } from "./config";
+import { DEFAULT_TOOLS_DIR } from "./config/constants";
 
 /** Config type for the user to provide */
 export type XmcpInputConfig = Omit<InputSchema, "webpack"> & {

--- a/packages/xmcp/src/index.ts
+++ b/packages/xmcp/src/index.ts
@@ -4,7 +4,7 @@ dotenv.config();
 
 export type { ToolMetadata, ToolSchema, InferSchema } from "./types/tool";
 
-export type { XmcpInputConfig as XmcpConfig } from "./compiler/parse-xmcp-config";
+export type { XmcpConfigOuputSchema as XmcpConfig } from "./compiler/config";
 export { apiKeyAuthMiddleware } from "./auth/api-key";
 export { jwtAuthMiddleware } from "./auth/jwt";
 export type { OAuthConfigOptions } from "./auth/oauth";

--- a/packages/xmcp/src/runtime/transports/http/base-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/base-streamable-http.ts
@@ -6,7 +6,6 @@ export interface HttpTransportOptions {
   endpoint?: string;
   bodySizeLimit?: string;
   debug?: boolean;
-  bindToLocalhost?: boolean;
 }
 
 export interface JsonRpcMessage {

--- a/packages/xmcp/src/runtime/transports/http/base-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/base-streamable-http.ts
@@ -2,6 +2,7 @@ import { IncomingMessage, ServerResponse } from "http";
 
 export interface HttpTransportOptions {
   port?: number;
+  host?: string;
   endpoint?: string;
   bodySizeLimit?: string;
   debug?: boolean;

--- a/packages/xmcp/src/runtime/transports/http/setup-cors.ts
+++ b/packages/xmcp/src/runtime/transports/http/setup-cors.ts
@@ -1,7 +1,7 @@
 import { Response } from "express";
-import { CorsOptions } from "./stateless-streamable-http";
+import { CorsConfig } from "@/compiler/config/schemas";
 
-export function setResponseCorsHeaders(cors: CorsOptions, res: Response) {
+export function setResponseCorsHeaders(cors: CorsConfig, res: Response) {
   // set cors headers dynamically
   if (cors.origin !== undefined)
     res.setHeader(

--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -279,7 +279,6 @@ export class StatelessStreamableHTTPTransport {
     middlewares?: RequestHandler[]
   ) {
     this.options = {
-      bindToLocalhost: true,
       ...options,
     };
     this.app = express();
@@ -290,9 +289,6 @@ export class StatelessStreamableHTTPTransport {
     this.createServerFn = createServerFn;
     this.corsConfig = corsConfig;
     this.middlewares = middlewares;
-
-    console.log("corsConfig", this.corsConfig);
-    console.log("options", options);
 
     // setup oauth proxy if configuration is provided
     if (oauthConfig) {
@@ -402,9 +398,7 @@ export class StatelessStreamableHTTPTransport {
   }
 
   public start(): void {
-    const host =
-      this.options.host ||
-      (this.options.bindToLocalhost ? "127.0.0.1" : "0.0.0.0");
+    const host = this.options.host || "127.0.0.1";
 
     this.server.listen(this.port, host, () => {
       console.log(


### PR DESCRIPTION
Splitted the compiler config into schemas + files for readability/scalability.
Added constants, injection functions and resolve configurations.
Implement injected variables from HTTP as groups.
Reuse schemas.
Added host to bind transport.
Added default CORS regardless of setting -> compliant with clients.