### PR TITLE
Disable localhost only flag by default

### DIFF
--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -287,7 +287,7 @@ export class StatelessStreamableHTTPTransport {
     middlewares?: RequestHandler[]
   ) {
     this.options = {
-      bindToLocalhost: true,
+      bindToLocalhost: false,
       ...options,
     };
     this.app = express();


### PR DESCRIPTION
I want to be able to debug it on different devices. I think it would make sense to disable this flag by default and later introduce the user parameter.