### PR TITLE
feat(create-xmcp-app): Add support for Bun package manager in project creation and installation scripts

### DIFF
--- a/packages/create-xmcp-app/src/helpers/install.ts
+++ b/packages/create-xmcp-app/src/helpers/install.ts
@@ -2,7 +2,7 @@ import { execSync } from "child_process";
 
 /**
  * Get the appropriate install command for the selected package manager
- * @param packageManager - Package manager name (npm, yarn, or pnpm)
+ * @param packageManager - Package manager name (npm, yarn, pnpm, or bun)
  * @returns Install command string with appropriate flags
  */
 function getInstallCommand(
@@ -15,6 +15,8 @@ function getInstallCommand(
       return `yarn install --check-engines xmcp@${packageVersion}`;
     case "pnpm":
       return `pnpm install xmcp@${packageVersion}`;
+    case "bun":
+      return `bun install xmcp@${packageVersion}`;
     case "npm":
     default:
       // npm automatically checks engines by default
@@ -25,7 +27,7 @@ function getInstallCommand(
 /**
  * Install project dependencies using the specified package manager
  * @param projectPath - Project directory path where dependencies should be installed
- * @param packageManager - Package manager to use (npm, yarn, or pnpm)
+ * @param packageManager - Package manager to use (npm, yarn, pnpm, or bun)
  */
 export function install(
   projectPath: string,

--- a/packages/create-xmcp-app/src/index.ts
+++ b/packages/create-xmcp-app/src/index.ts
@@ -35,6 +35,7 @@ const program = new Command()
   .option("--use-npm", "Use npm as package manager (default: use npm)")
   .option("--use-yarn", "Use yarn as package manager")
   .option("--use-pnpm", "Use pnpm as package manager")
+  .option("--use-bun", "Use bun as package manager")
   .option("--skip-install", "Skip installing dependencies", false)
   .option("--vercel", "Add Vercel support for deployment", false)
   .option("--http", "Enable HTTP transport", false)
@@ -94,8 +95,14 @@ const program = new Command()
     if (!options.yes) {
       if (options.useYarn) packageManager = "yarn";
       if (options.usePnpm) packageManager = "pnpm";
+      if (options.useBun) packageManager = "bun";
 
-      if (!options.useYarn && !options.usePnpm && !options.useNpm) {
+      if (
+        !options.useYarn &&
+        !options.usePnpm &&
+        !options.useBun &&
+        !options.useNpm
+      ) {
         const pmAnswers = await inquirer.prompt([
           {
             type: "list",
@@ -105,6 +112,7 @@ const program = new Command()
               { name: "npm", value: "npm" },
               { name: "yarn", value: "yarn" },
               { name: "pnpm", value: "pnpm" },
+              { name: "bun", value: "bun" },
             ],
             default: "npm",
           },
@@ -176,6 +184,7 @@ const program = new Command()
       // Use command-line options when --yes is provided
       if (options.useYarn) packageManager = "yarn";
       if (options.usePnpm) packageManager = "pnpm";
+      if (options.useBun) packageManager = "bun";
     }
 
     const spinner = ora("Creating your xmcp app...").start();
@@ -206,6 +215,9 @@ const program = new Command()
       } else if (packageManager === "pnpm") {
         skipInstall && console.log(`  ${chalk.cyan("pnpm install")}`);
         console.log(`  ${chalk.cyan("pnpm dev")}`);
+      } else if (packageManager === "bun") {
+        skipInstall && console.log(`  ${chalk.cyan("bun install")}`);
+        console.log(`  ${chalk.cyan("bun dev")}`);
       } else {
         skipInstall && console.log(`  ${chalk.cyan("npm install")}`);
         console.log(`  ${chalk.cyan("npm run dev")}`);

--- a/packages/init-xmcp/README.md
+++ b/packages/init-xmcp/README.md
@@ -27,7 +27,7 @@ npx init-xmcp@latest
 
 - `-v, --version`: Output the current version of init-xmcp.
 - `-y, --yes`: Skip confirmation prompts (default: false)
-- `--package-manager <manager>`: Specify package manager (npm, yarn, pnpm) (default: "")
+- `--package-manager <manager>`: Specify package manager (npm, yarn, pnpm, bun) (default: "")
 - `--tools-path <path>`: Specify custom tools path (default: "")
 - `--route-path <path>`: Specify custom route path (default: "")
 - `--skip-tools`: Skip tool creation (default: false)

--- a/packages/init-xmcp/src/helpers/install.ts
+++ b/packages/init-xmcp/src/helpers/install.ts
@@ -12,7 +12,10 @@ import { execSync } from "child_process";
  */
 export function detectPackageManager(
   projectPath: string
-): "npm" | "yarn" | "pnpm" | null {
+): "npm" | "yarn" | "pnpm" | "bun" | null {
+  if (fs.existsSync(path.join(projectPath, "bun.lockb"))) {
+    return "bun";
+  }
   if (fs.existsSync(path.join(projectPath, "yarn.lock"))) {
     return "yarn";
   }
@@ -31,7 +34,7 @@ export function detectPackageManager(
  */
 export async function install(
   projectPath: string,
-  packageManager: "npm" | "pnpm" | "yarn"
+  packageManager: "npm" | "pnpm" | "yarn" | "bun"
 ) {
   const dependencies = ["xmcp", "zod"];
   const devDependencies = ["swc-loader"];
@@ -40,6 +43,7 @@ export async function install(
     npm: `npm install ${dependencies.join(" ")} && npm install --save-dev ${devDependencies.join(" ")}`,
     pnpm: `pnpm add ${dependencies.join(" ")} && pnpm add --save-dev ${devDependencies.join(" ")}`,
     yarn: `yarn add ${dependencies.join(" ")} && yarn add --dev ${devDependencies.join(" ")}`,
+    bun: `bun add ${dependencies.join(" ")} && bun add --dev ${devDependencies.join(" ")}`,
   };
 
   try {

--- a/packages/init-xmcp/src/index.ts
+++ b/packages/init-xmcp/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command()
   .option("-y, --yes", "Skip confirmation prompts", false)
   .option(
     "--package-manager <manager>",
-    "Specify package manager (npm, yarn, pnpm)",
+    "Specify package manager (npm, yarn, pnpm, bun)",
     ""
   )
   .option("--tools-path <path>", "Specify custom tools path", "")
@@ -102,11 +102,15 @@ const program = new Command()
     }
 
     // determine package manager
-    let packageManager: "npm" | "yarn" | "pnpm";
+    let packageManager: "npm" | "yarn" | "pnpm" | "bun";
     if (detectedPackageManager) {
       packageManager = detectedPackageManager;
     } else if (options.packageManager) {
-      packageManager = options.packageManager as "npm" | "yarn" | "pnpm";
+      packageManager = options.packageManager as
+        | "npm"
+        | "yarn"
+        | "pnpm"
+        | "bun";
     } else {
       // no package manager detected, will prompt user
       packageManager = "npm"; // default fallback

--- a/packages/xmcp/src/utils/detect-package-manager.ts
+++ b/packages/xmcp/src/utils/detect-package-manager.ts
@@ -10,8 +10,15 @@ export function detectPackageManager(): {
   const pnpmLock = path.join(processFolder, "pnpm-lock.yaml");
   const npmLock = path.join(processFolder, "package-lock.json");
   const yarnLock = path.join(processFolder, "yarn.lock");
+  const bunLock = path.join(processFolder, "bun.lockb");
 
-  if (fs.existsSync(pnpmLock)) {
+  if (fs.existsSync(bunLock)) {
+    return {
+      manager: "bun",
+      lockFile: "bun.lockb",
+      installCmd: "bun install",
+    };
+  } else if (fs.existsSync(pnpmLock)) {
     return {
       manager: "pnpm",
       lockFile: "pnpm-lock.yaml",


### PR DESCRIPTION

> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**

## Summary

  - Add bun as a package manager option across all xmcp tools
  - Update package manager detection to recognize bun.lockb files
  - Add --use-bun CLI flag to create-xmcp-app
  - Updated detectPackageManager functions to detect bun.lockb files and return "bun" as the package manager

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fixing
- [x] Adding a feature
- [ ] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [ ] `xmcp` (core framework)
- [x] `create-xmcp-app`
- [x] `init-xmcp`
- [x] Documentation
- [ ] Examples

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->

## Related Issues

<!-- Link any related issues: "Fixes #123" or "Closes #456" -->
Closes #63 (Old PR)
