### PR TITLE
feat: refactor HTTP transport to use dynamic port allocation

### DIFF
--- a/packages/xmcp/src/runtime/transports/http/index.ts
+++ b/packages/xmcp/src/runtime/transports/http/index.ts
@@ -84,7 +84,7 @@ async function main() {
     oauthConfig,
     middlewareFn
   );
-  transport.start();
+  await transport.start();
 }
 
 main();

--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -20,6 +20,7 @@ import { httpContextProvider } from "./http-context";
 import { createOAuthProxy, type OAuthProxyConfig } from "../../../auth/oauth";
 import { OAuthProxy } from "../../../auth/oauth/factory";
 import { greenCheck } from "../../../utils/cli-icons";
+import { findAvailablePort } from "../../../utils/port-utils";
 import { setResponseCorsHeaders } from "./setup-cors";
 import { CorsConfig } from "@/compiler/config/schemas";
 
@@ -283,7 +284,7 @@ export class StatelessStreamableHTTPTransport {
     };
     this.app = express();
     this.server = http.createServer(this.app);
-    this.port = options.port ?? parseInt(process.env.PORT || "3001", 10);
+    this.port = options.port ?? parseInt(process.env.PORT || "3002", 10);
     this.endpoint = options.endpoint ?? "/mcp";
     this.debug = options.debug ?? false;
     this.createServerFn = createServerFn;
@@ -397,26 +398,27 @@ export class StatelessStreamableHTTPTransport {
     }
   }
 
-  public start(): void {
+  public async start(): Promise<void> {
     const host = this.options.host || "127.0.0.1";
+    const port = await findAvailablePort(this.port, host);
 
-    this.server.listen(this.port, host, () => {
+    this.server.listen(port, host, () => {
       console.log(
-        `${greenCheck} MCP Server running on http://${host}:${this.port}${this.endpoint}`
+        `${greenCheck} MCP Server running on http://${host}:${port}${this.endpoint}`
       );
 
       if (this.oauthProxy && this.debug) {
         console.log(`🔐 OAuth endpoints available:`);
         console.log(
-          `   Discovery: http://${host}:${this.port}/.well-known/oauth-authorization-server`
+          `   Discovery: http://${host}:${port}/.well-known/oauth-authorization-server`
         );
         console.log(
-          `   Authorize: http://${host}:${this.port}/oauth2/authorize`
+          `   Authorize: http://${host}:${port}/oauth2/authorize`
         );
-        console.log(`   Token: http://${host}:${this.port}/oauth2/token`);
-        console.log(`   Revoke: http://${host}:${this.port}/oauth2/revoke`);
+        console.log(`   Token: http://${host}:${port}/oauth2/token`);
+        console.log(`   Revoke: http://${host}:${port}/oauth2/revoke`);
         console.log(
-          `   Introspect: http://${host}:${this.port}/oauth2/introspect`
+          `   Introspect: http://${host}:${port}/oauth2/introspect`
         );
       }
 

--- a/packages/xmcp/src/utils/port-utils.ts
+++ b/packages/xmcp/src/utils/port-utils.ts
@@ -1,0 +1,43 @@
+import chalk from "chalk";
+import net from "net";
+import { yellowArrow } from "./cli-icons";
+
+const checkPortAvailability = (port: number, host: string) => {
+  const server = net.createServer();
+
+  return new Promise((resolve, reject) => {
+    server.once("error", (err) => {
+      if ("code" in err && err.code === "EADDRINUSE") {
+        // port is currently in use
+        resolve(false);
+      } else {
+        reject(err);
+      }
+    });
+
+    server.once("listening", () => {
+      server.close();
+      resolve(true);
+    });
+
+    server.listen(port, host);
+  });
+};
+
+export async function findAvailablePort(
+  startPort: number = 3002,
+  host: string = "127.0.0.1"
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    checkPortAvailability(startPort, host).then((isAvailable) => {
+      if (isAvailable) {
+        resolve(startPort);
+      } else {
+        console.log(
+          `${yellowArrow} Port ${chalk.yellow(String(startPort))} is in use, trying ${chalk.yellow(String(startPort + 1))} instead.`
+        );
+        findAvailablePort(startPort + 1).then(resolve);
+      }
+    });
+  });
+}

--- a/packages/xmcp/src/utils/port-utils.ts
+++ b/packages/xmcp/src/utils/port-utils.ts
@@ -28,7 +28,7 @@ export async function findAvailablePort(
   startPort: number = 3002,
   host: string = "127.0.0.1"
 ): Promise<number> {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     checkPortAvailability(startPort, host).then((isAvailable) => {
       if (isAvailable) {
         resolve(startPort);


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**

## Summary

<!-- Brief description of changes -->

Refactors the HTTP transport to use dynamic port allocation, preventing port conflicts when multiple server instances are running. The implementation automatically finds the next available port when the default port is in use.

If the HTTP port is not explicitly configured, it searches for an available port starting from 3002 and incrementing upwards.

- Updated HTTP transport to use dynamic port allocation
- Created new `port-utils.ts` file to encapsulate port allocation logic
- Made the `start()` method asynchronous to support port discovery
- Added user-friendly console messages when port fallback occurs

## Type of Change

- [ ] Bug fixing
- [x] Adding a feature
- [ ] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [x] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [ ] Documentation
- [ ] Examples

## Screenshots/Examples

**Before (problematic behavior):**
```bash
# Two processes already running on port 3002
$ pnpm run dev
 XMCP  Starting development mode...
✔ Compiled in 528ms
✔ Built HTTP server
❯ Starting http server
node:events:502
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE: address already in use 127.0.0.1:3002
    at Server.setupListenHandle [as _listen2] (node:net:1908:16)
    at listenInCluster (node:net:1965:12)
    at doListen (node:net:2139:7)
    at process.processTicksAndRejections (node:internal/process/task_queues:83:21)
Emitted 'error' event on Server instance at:
    at emitErrorNT (node:net:1944:8)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'EADDRINUSE',
  errno: -48,
  syscall: 'listen',
  address: '127.0.0.1',
  port: 3002
}

```

**After (fixed behavior):**

```bash
# Two processes already running on port 3002
$ pnpm run dev
 XMCP  Starting development mode...
✔ Compiled in 502ms
✔ Built HTTP server
❯ Starting http server
❯ Port 3002 is in use, trying 3003 instead.
✔ MCP Server running on http://127.0.0.1:3003/mcp
```

<img width="913" height="740" alt="image" src="https://github.com/user-attachments/assets/6d7e8a57-2777-4279-9774-4f156f8b0760" />


## Related Issues

<!-- Link any related issues: "Fixes #123" or "Closes #456" -->
Resolves https://github.com/basementstudio/xmcp/issues/89
