### PR TITLE
Normalize HTTP config port usage

### DIFF
--- a/packages/create-xmcp-app/src/helpers/generate-config.ts
+++ b/packages/create-xmcp-app/src/helpers/generate-config.ts
@@ -19,9 +19,7 @@ const config: XmcpConfig = {`;
 
   if (hasHttp) {
     configContent += `
-  http: {
-    port: 3002,
-  },`;
+  http: true,`;
   }
 
   if (hasStdio) {

--- a/packages/xmcp/src/compiler/config/constants.ts
+++ b/packages/xmcp/src/compiler/config/constants.ts
@@ -23,7 +23,7 @@ export const DEFAULT_CORS_CONFIG = {
  * Default values for the HTTP transport
  */
 export const DEFAULT_HTTP_CONFIG = {
-  port: 3002,
+  port: 3001,
   host: "127.0.0.1",
   bodySizeLimit: 1024 * 1024 * 10, // 10MB
   debug: false,

--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -284,7 +284,7 @@ export class StatelessStreamableHTTPTransport {
     };
     this.app = express();
     this.server = http.createServer(this.app);
-    this.port = options.port ?? parseInt(process.env.PORT || "3002", 10);
+    this.port = options.port ?? parseInt(process.env.PORT || "3001", 10);
     this.endpoint = options.endpoint ?? "/mcp";
     this.debug = options.debug ?? false;
     this.createServerFn = createServerFn;
@@ -412,14 +412,10 @@ export class StatelessStreamableHTTPTransport {
         console.log(
           `   Discovery: http://${host}:${port}/.well-known/oauth-authorization-server`
         );
-        console.log(
-          `   Authorize: http://${host}:${port}/oauth2/authorize`
-        );
+        console.log(`   Authorize: http://${host}:${port}/oauth2/authorize`);
         console.log(`   Token: http://${host}:${port}/oauth2/token`);
         console.log(`   Revoke: http://${host}:${port}/oauth2/revoke`);
-        console.log(
-          `   Introspect: http://${host}:${port}/oauth2/introspect`
-        );
+        console.log(`   Introspect: http://${host}:${port}/oauth2/introspect`);
       }
 
       this.setupShutdownHandlers();

--- a/packages/xmcp/src/utils/port-utils.ts
+++ b/packages/xmcp/src/utils/port-utils.ts
@@ -25,7 +25,7 @@ const checkPortAvailability = (port: number, host: string) => {
 };
 
 export async function findAvailablePort(
-  startPort: number = 3002,
+  startPort: number = 3001,
   host: string = "127.0.0.1"
 ): Promise<number> {
   return new Promise((resolve) => {


### PR DESCRIPTION
Start HTTP project with

```
http: true
```

instead of manually setting the port, and changed default to 3001.