### PR TITLE
fix(init-xmcp): support comments and trailing commas in tsconfig.json | Fixes #109

### DIFF
--- a/packages/init-xmcp/package.json
+++ b/packages/init-xmcp/package.json
@@ -48,6 +48,9 @@
     "inquirer": "^9.2.12",
     "ora": "^7.0.1"
   },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/inquirer": "^9.0.7",

--- a/packages/init-xmcp/src/helpers/detect-framework.ts
+++ b/packages/init-xmcp/src/helpers/detect-framework.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import fs from "fs-extra";
 import path from "path";
+import { readTsConfigFile } from "../utils/read-config-file.js";
 
 export type Framework = "nextjs" | "express";
 
@@ -38,14 +39,13 @@ export function detectTypeScript(projectRoot: string): boolean {
   // if typescript is in the dependencies, check for tsconfig.json and validate it
   if (fs.existsSync(path.join(projectRoot, "tsconfig.json"))) {
     try {
-      const tsconfigContent = fs.readJsonSync(
-        path.join(projectRoot, "tsconfig.json")
-      );
+      const tsconfigPath = path.join(projectRoot, "tsconfig.json");
+      const tsconfigContent = readTsConfigFile(tsconfigPath);
       return typeof tsconfigContent === "object" && tsconfigContent !== null;
-    } catch {
+    } catch (error) {
       console.log(
         chalk.yellow(
-          "Please initialize xmcp within a TypeScript project. Invalid tsconfig.json file"
+          `Please initialize xmcp within a TypeScript project. ${error instanceof Error ? error.message : "Invalid tsconfig.json file"}`
         )
       );
       return false;

--- a/packages/init-xmcp/src/helpers/update-tsconfig.ts
+++ b/packages/init-xmcp/src/helpers/update-tsconfig.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import fs from "fs-extra";
 import chalk from "chalk";
+import { readTsConfigFile } from "../utils/read-config-file.js";
 
 /**
  * updates the tsconfig.json file to include the @xmcp/* alias for accessing the handler
@@ -9,7 +10,16 @@ import chalk from "chalk";
  */
 export function updateTsConfig(projectRoot: string) {
   const tsconfigPath = path.join(projectRoot, "tsconfig.json");
-  const tsconfig = fs.readJsonSync(tsconfigPath);
+  
+  let tsconfig: any;
+  try {
+    tsconfig = readTsConfigFile(tsconfigPath);
+  } catch (error) {
+    console.log(
+      chalk.yellow(`Failed to parse tsconfig.json: ${error instanceof Error ? error.message : "Unknown error"}`)
+    );
+    return;
+  }
 
   if (!tsconfig) {
     console.log(

--- a/packages/init-xmcp/src/utils/read-config-file.ts
+++ b/packages/init-xmcp/src/utils/read-config-file.ts
@@ -1,0 +1,11 @@
+import ts from "typescript";
+
+export function readTsConfigFile<T = any>(filePath: string): T {
+  const { config, error } = ts.readConfigFile(filePath, ts.sys.readFile);
+  if (error) {
+    throw new Error(
+      `Invalid tsconfig.json → ${ts.flattenDiagnosticMessageText(error.messageText, "\n")}`
+    );
+  }
+  return config as T;
+}


### PR DESCRIPTION
## Summary

Fix `init-xmcp` to support TypeScript configuration files with comments and trailing commas. This resolves the issue where `init-xmcp` would fail with "Invalid tsconfig.json file" when encountering valid TypeScript syntax that includes comments or trailing commas, which are commonly used in T3 Stack projects and other modern TypeScript setups.

## Type of Change

- [x] Bug fixing
- [ ] Adding a feature
- [ ] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [ ] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [x] `init-xmcp`
- [ ] Documentation
- [ ] Examples

## Screenshots/Examples

### Before (failing)
```bash
init-xmcp@0.1.7
Please initialize xmcp within a TypeScript project. Invalid tsconfig.json file
```

### After (working)
```bash
init-xmcp@0.1.7
✔ xmcp initialized successfully!
```

### Example tsconfig.json that now works
```json
{
  "compilerOptions": {
    "target": "es2016",
    "module": "commonjs",
    "esModuleInterop": true,
    "strict": true,
    "skipLibCheck": true,
    "rootDir": "./src", // This comment now works
    "outDir": "./dist", // This trailing comma now works
  },
  "include": [
    "src/**/*.ts" // Comments in arrays work too
  ]
}
```

## Related Issues

Fixes #109

## Technical Details

- **Solution**: Use TypeScript's official API (`ts.readConfigFile`) instead of `JSON.parse`
- **Dependencies**: Added `typescript` as peerDependency (already required in XMCP projects)
- **Files changed**: 
  - `packages/init-xmcp/src/utils/read-config-file.ts` (new helper)
  - `packages/init-xmcp/src/helpers/detect-framework.ts` (use new helper)
  - `packages/init-xmcp/src/helpers/update-tsconfig.ts` (use new helper)
  - `packages/init-xmcp/package.json` (add peerDependency)

This change ensures `init-xmcp` works seamlessly with modern TypeScript projects that use comments and trailing commas in their configuration files, improving the developer experience for T3 Stack and similar projects.