### PR TITLE
Update Vercel starter to help with zero-configuration

### DIFF
--- a/examples/vercel-deploy/package.json
+++ b/examples/vercel-deploy/package.json
@@ -2,7 +2,7 @@
   "name": "vercel-deploy",
   "description": "Deploy your xmcp server to vercel",
   "scripts": {
-    "build": "xmcp build",
+    "build": "xmcp build --vercel",
     "dev": "xmcp dev",
     "start": "node dist/http.js"
   },


### PR DESCRIPTION
We're putting together a zero-configuration Framework Preset for Vercel in https://github.com/vercel/vercel/pull/13770, and I noticed that the build command doesn't use the `--vercel` flag. This means that our Framework Preset will try to use the `build` script from package.json, and subsequently produce incompatible build output.

It stands to reason that, if someone chooses the Vercel deployment option while scaffolding, that they're going to want to be using the deployment adapter as well, so this makes everything Just Work™️!