### PR TITLE
Update docs to reflect Cursor and Claude Desktop differences

### DIFF
--- a/apps/website/src/docs/index.mdx
+++ b/apps/website/src/docs/index.mdx
@@ -258,7 +258,7 @@ node dist/http.js
 
 At this point, you can configure your MCP server on clients like `Cursor` or `Claude Desktop`.
 
-If you're using the HTTP transport, your configuration should look like this:
+If you're using the HTTP transport with Cursor, your configuration should look like this:
 
 ```json
 {
@@ -270,6 +270,18 @@ If you're using the HTTP transport, your configuration should look like this:
 }
 ```
 
+If you're using the HTTP transport with Claude Desktop, your configuration should look like this:
+
+```json
+{
+  "mcpServers": {
+    "my-project": {
+        "command": "npx",
+        "args": ["-y", "mcp-remote", "http://localhost:3000/mcp"]
+    }
+  }
+}
+```
 If you're using the STDIO transport, your configuration for local development should look like this:
 
 ```json


### PR DESCRIPTION
## Summary

Claude Desktop requires "command", while Cursor works with the currently published documentation. Updating the docs to reflect this: https://xmcp.dev/docs#connecting-to-your-server

Tested both and both configurations work.
**Cannot run the docs because of a missing BASEHUB_TOKEN.**

## Type of Change

- [ ] Bug fixing
- [ ] Adding a feature
- [X] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [ ] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [X] Documentation
- [ ] Examples
