### PR TITLE
feat(create-xmcp-app): Add option to customize initialized components

### DIFF
--- a/packages/create-xmcp-app/package.json
+++ b/packages/create-xmcp-app/package.json
@@ -50,8 +50,9 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
-    "@types/inquirer": "^9.0.7",
+    "@types/inquirer": "^9.0.9",
     "@types/node": "^20.17.47",
+    "@types/ora": "^3.1.0",
     "typescript": "^5.3.3"
   }
 }

--- a/packages/create-xmcp-app/src/helpers/copy-template.ts
+++ b/packages/create-xmcp-app/src/helpers/copy-template.ts
@@ -5,11 +5,22 @@ import fs from "fs-extra";
  * Copy template files to the project directory, excluding unnecessary files
  * @param templateDir - Source template directory path
  * @param projectPath - Destination project directory path
+ * @param paths - Array of paths to include (tools, prompts)
  */
-export function copyTemplate(templateDir: string, projectPath: string): void {
+export function copyTemplate(templateDir: string, projectPath: string, paths: string[] = ["tools", "prompts"]): void {
   fs.copySync(templateDir, projectPath, {
     filter: (src) => {
       const basename = path.basename(src);
+      const relativePath = path.relative(templateDir, src);
+      const srcDir = path.dirname(relativePath).split(path.sep)[0];
+      
+      // Check if this is a source directory that should be included based on user selection
+      if (srcDir === "src") {
+        const subDir = relativePath.split(path.sep)[1];
+        if (subDir === "tools" && !paths.includes("tools")) return false;
+        if (subDir === "prompts" && !paths.includes("prompts")) return false;
+      }
+      
       return (
         // node_modules could be skipped
         basename !== "node_modules" &&

--- a/packages/create-xmcp-app/src/helpers/create.ts
+++ b/packages/create-xmcp-app/src/helpers/create.ts
@@ -17,6 +17,7 @@ interface ProjectOptions {
   transports: string[];
   packageVersion: string;
   skipInstall?: boolean;
+  paths?: string[];
 }
 
 /**
@@ -39,6 +40,7 @@ export function createProject(options: ProjectOptions): void {
     transports,
     packageVersion,
     skipInstall,
+    paths = ["tools", "prompts"],
   } = options;
 
   // Ensure the project directory exists
@@ -48,13 +50,13 @@ export function createProject(options: ProjectOptions): void {
   const templateDir = path.join(__dirname, "../../templates", "typescript");
 
   // Copy template files to project directory
-  copyTemplate(templateDir, projectPath);
+  copyTemplate(templateDir, projectPath, paths);
 
   // Rename special files (e.g., _gitignore to .gitignore)
   renameFiles(projectPath);
 
-  // Generate xmcp.config.ts based on selected transports
-  generateConfig(projectPath, transports);
+  // Generate xmcp.config.ts based on selected transports and paths
+  generateConfig(projectPath, transports, paths);
 
   // Update package.json with project configuration
   updatePackageJson(projectPath, projectName, transports);

--- a/packages/create-xmcp-app/src/helpers/generate-config.ts
+++ b/packages/create-xmcp-app/src/helpers/generate-config.ts
@@ -2,13 +2,15 @@ import path from "path";
 import fs from "fs-extra";
 
 /**
- * Generate xmcp.config.ts based on selected transports
+ * Generate xmcp.config.ts based on selected transports and paths
  * @param projectPath - Project directory path
  * @param transports - Array of selected transport types
+ * @param paths - Array of selected paths (tools, prompts)
  */
 export function generateConfig(
   projectPath: string,
-  transports: string[]
+  transports: string[],
+  paths: string[] = ["tools", "prompts"]
 ): void {
   const hasHttp = transports.includes("http");
   const hasStdio = transports.includes("stdio");
@@ -27,6 +29,29 @@ const config: XmcpConfig = {`;
   stdio: true,`;
   }
 
+  // Add paths configuration
+  configContent += `
+  paths: {`;
+
+  // Add tools path if selected
+  if (paths.includes("tools")) {
+    configContent += `
+    tools: "./src/tools",`;
+  }
+
+  // Add prompts path if selected
+  if (paths.includes("prompts")) {
+    configContent += `
+    prompts: "./src/prompts",`;
+  }
+
+  // Close the paths object
+  configContent += `
+  },`;
+
+  // Remove trailing comma if present
+  configContent = configContent.endsWith(',') ? configContent.slice(0, -1) : configContent;
+  
   configContent += `
 };
 

--- a/packages/create-xmcp-app/src/index.ts
+++ b/packages/create-xmcp-app/src/index.ts
@@ -81,6 +81,7 @@ const program = new Command()
     let packageManager = "npm";
     let skipInstall = options.skipInstall;
     let transports = ["http"];
+    let selectedPaths = ["tools", "prompts"];
 
     // Handle transport selection from CLI options
     if (options.http || options.stdio) {
@@ -140,6 +141,28 @@ const program = new Command()
         transports = [transportAnswers.transport];
       }
 
+      // Path selection checklist
+      const pathAnswers = await inquirer.prompt([
+        {
+          type: "checkbox",
+          name: "paths",
+          message: "Select components to initialize:",
+          choices: [
+            {
+              name: "Tools",
+              value: "tools",
+              checked: true,
+            },
+            {
+              name: "Prompts",
+              value: "prompts",
+              checked: true,
+            }
+          ]
+        }
+      ]);
+      selectedPaths = pathAnswers.paths;
+
       console.log();
       console.log(
         `Creating a new xmcp app in ${chalk.green(resolvedProjectPath)}.\n`
@@ -163,6 +186,9 @@ const program = new Command()
       if (options.useYarn) packageManager = "yarn";
       if (options.usePnpm) packageManager = "pnpm";
       if (options.useBun) packageManager = "bun";
+      
+      // Use all paths by default in non-interactive mode
+      selectedPaths = ["tools", "prompts"];
     }
 
     const spinner = ora("Creating your xmcp app...").start();
@@ -174,6 +200,7 @@ const program = new Command()
         transports: transports,
         packageVersion: packageJson.version,
         skipInstall,
+        paths: selectedPaths
       });
 
       spinner.succeed(chalk.green("Your xmcp app is ready"));


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**

## Summary

<!-- Brief description of changes -->
Add option to customize initialized components in create-xmcp-app CLI

## Type of Change

- [ ] Bug fixing
- [x] Adding a feature
- [ ] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [ ] `xmcp` (core framework)
- [x] `create-xmcp-app`
- [ ] `init-xmcp`
- [ ] Documentation
- [ ] Examples

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->
<img width="802" height="135" alt="Screenshot from 2025-09-09 18-32-14" src="https://github.com/user-attachments/assets/e3e06c17-999e-403f-96cd-a9d055a29650" />

## Related Issues

<!-- Link any related issues: "Fixes #123" or "Closes #456" -->
Closes #145 
