### PR TITLE
feat: add fork-ts-checker-webpack-plugin for type checking

### DIFF
--- a/packages/xmcp/src/compiler/get-webpack-config/index.ts
+++ b/packages/xmcp/src/compiler/get-webpack-config/index.ts
@@ -13,6 +13,7 @@ import { getEntries } from "./get-entries";
 import { getInjectedVariables } from "./get-injected-variables";
 import { resolveTsconfigPathsToAlias } from "./resolve-tsconfig-paths";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
+import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import { CreateTypeDefinitionPlugin, InjectRuntimePlugin } from "./plugins";
 import { getExternals } from "./get-externals";
 
@@ -61,7 +62,11 @@ export function getWebpackConfig(
         path.resolve(__dirname, "../.."), // for pnpm
       ],
     },
-    plugins: [new InjectRuntimePlugin(), new CreateTypeDefinitionPlugin()],
+    plugins: [
+      new InjectRuntimePlugin(),
+      new CreateTypeDefinitionPlugin(),
+      new ForkTsCheckerWebpackPlugin(),
+    ],
     module: {
       rules: [
         {


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**

## Summary
add fork-ts-checker-webpack-plugin (already installed) to webpack config

is non-blocking at runtime

## Type of Change

- [ ] Bug fixing
- [x] Adding a feature
- [ ] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [x] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [ ] Documentation
- [ ] Examples

## Screenshots/Examples


## Related Issues
https://github.com/basementstudio/xmcp/issues/185