### PR TITLE
chore: use config.name as compiler key

### DIFF
--- a/packages/xmcp/bundler/build-main.ts
+++ b/packages/xmcp/bundler/build-main.ts
@@ -54,6 +54,7 @@ function getConfig() {
   }
 
   const config: RspackOptions = {
+    name: "main",
     entry: {
       index: path.join(srcPath, "index.ts"),
       cli: path.join(srcPath, "cli.ts"),
@@ -207,5 +208,5 @@ export function buildMain() {
     console.log(chalk.bgGreen.bold("xmcp compiled"));
   };
 
-  runCompiler(config, handleStats, "main");
+  runCompiler(config, handleStats);
 }

--- a/packages/xmcp/bundler/build-runtime.ts
+++ b/packages/xmcp/bundler/build-runtime.ts
@@ -35,6 +35,7 @@ for (const root of runtimeRoots) {
 }
 
 const config: RspackOptions = {
+  name: "runtime",
   entry,
   mode: "production",
   devtool: false,
@@ -173,5 +174,5 @@ export function buildRuntime(onCompiled: (stats: any) => void) {
     }
   };
 
-  runCompiler(config, handleStats, "runtime");
+  runCompiler(config, handleStats);
 }

--- a/packages/xmcp/bundler/compiler-manager.ts
+++ b/packages/xmcp/bundler/compiler-manager.ts
@@ -67,8 +67,7 @@ export function getCompiler(config: RspackOptions, key?: string): Compiler {
 
 export function runCompiler(
   config: RspackOptions,
-  callback: (err: Error | null, stats: any) => void,
-  key?: string
+  callback: (err: Error | null, stats: any) => void
 ): void {
-  return compilerManager.run(config, callback, key);
+  return compilerManager.run(config, callback, config?.name);
 }


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**

## Summary

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fixing
- [ ] Adding a feature
- [ ] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [ ] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [ ] Documentation
- [ ] Examples

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->

## Related Issues

<!-- Link any related issues: "Fixes #123" or "Closes #456" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `config.name` ("main"/"runtime") as the compiler key and remove the explicit key parameter from `runCompiler` calls.
> 
> - **Bundler**:
>   - Set `RspackOptions.name` for compilers: `"main"` in `packages/xmcp/bundler/build-main.ts` and `"runtime"` in `packages/xmcp/bundler/build-runtime.ts`.
>   - Simplify `runCompiler` usage by deriving the compiler key from `config.name` and removing the explicit key parameter in callers.
>   - Update `compiler-manager.ts` to have `runCompiler(config, callback)` delegate to `compilerManager.run(config, callback, config?.name)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc737381a7afcc6e0f40c7ade198cdcd32a0d78b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->