### PR TITLE
docs: remove --ui & --gpt from docs 

### DIFF
--- a/apps/website/content/docs/integrations/openai.mdx
+++ b/apps/website/content/docs/integrations/openai.mdx
@@ -12,26 +12,6 @@ xmcp provides first-class support for OpenAI's widget system, allowing you to cr
 
 When you define OpenAI metadata in your tools, xmcp automatically splits metadata into tool-specific and resource-specific properties and generates widget resources for your tools.
 
-## Quick Start
-
-Scaffold a new OpenAI-ready project:
-
-#### React Template
-
-The `--ui` flag scaffolds a project with React support.
-
-```bash
-npx create-xmcp-app --ui
-```
-
-#### Standard Template
-
-The `--gpt` flag scaffolds a project with template support.
-
-```bash
-npx create-xmcp-app --gpt
-```
-
 ## Approaches
 
 xmcp supports three approaches for creating OpenAI widgets:

--- a/packages/create-xmcp-app/README.md
+++ b/packages/create-xmcp-app/README.md
@@ -35,8 +35,6 @@ You will be asked for the project name and then guided through a series of promp
 - `--skip-install`: Skip installing dependencies
 - `--http`: Enable HTTP transport
 - `--stdio`: Enable STDIO transport
-- `--gpt`: Initialize with OpenAI/ChatGPT widgets template
-- `--ui`: Initialize with React widgets template
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
Remove flags from docs as --ui and --gpt deprecated.

## Type of Change

- [ ] Bug fixing
- [ ] Adding a feature
- [x] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [ ] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [x] Documentation
- [ ] Examples

## Screenshots/Examples


## Related Issues


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes deprecated --ui and --gpt flags and associated scaffolding instructions from the OpenAI integration docs and create-xmcp-app README.
> 
> - **Documentation**:
>   - **OpenAI Integration (`apps/website/content/docs/integrations/openai.mdx`)**:
>     - Remove Quick Start section that referenced `--ui` and `--gpt` scaffolding flags/templates.
>   - **CLI README (`packages/create-xmcp-app/README.md`)**:
>     - Remove `--gpt` and `--ui` options from the options list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f48bbcc94bd23fcd50a8bf6f9456697039788c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->