### PR TITLE
refactor: remove URL option from CLI

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,23 +8,12 @@ CLI tool for generating typed clients from xmcp MCP servers external connections
 npx @xmcp-dev/cli generate [options]
 ```
 
-## Options
-
-| Flag                   | Description         | Default          |
-| ---------------------- | ------------------- | ---------------- |
-| `-u, --url <url>`      | MCP server URL      | —                |
-| `-o, --out <path>`     | Output directory    | `src/generated`  |
-| `-c, --clients <path>` | Clients config file | `src/clients.ts` |
-
 ## Client Configuration
 
-Create a `src/clients.ts` file to define multiple MCP servers or STDIO packages:
+Define everything in `src/clients.ts` to use the full feature set:
 
 ```ts
 export const clients = {
-  remote: {
-    url: "https://my-remote-mcp.app/mcp",
-  },
   figma: {
     url: "https://mcp.figma.com/mcp",
     headers: [{ name: "x-api-key", env: "FIGMA_TOKEN" }],
@@ -34,14 +23,33 @@ export const clients = {
     args: ["--browser", "chromium"],
     env: { DEBUG: "pw:api,pw:browser*" },
   },
+  firecrawl: {
+    npm: "firecrawl-mcp",
+    env: { FIRECRAWL_API_KEY: process.env.FIRECRAWL_API_KEY ?? "" },
+  },
+  context7: {
+    command: "bunx",
+    args: [
+      "-y",
+      "@upstash/context7-mcp",
+      "--api-key",
+      process.env.CONTEXT7_KEY!,
+    ],
+  },
 };
 ```
 
 - Entries with a `url` use the HTTP transport (optional `headers` are supported, just like before).
-- Entries with `npm` (optionally `command`, `args`, `env`, `cwd`, `stderr`) use STDIO. The CLI will run `command` (defaults to `npx`) with `[npm, ...args]` to connect to the server and discover its tools.
+- Entries with `npm` (optionally `command`, `args`, `env`, `cwd`, `stderr`) use STDIO. The CLI runs `command` (defaults to `npx`) with `[npm, ...args]` and passes through `env`.
+- API keys can be provided either as CLI args (e.g., `["--api-key", process.env.CONTEXT7_KEY!]`) or via the `env` map. Prefer `env` for secrets.
 - STDIO packages must already be installed in the environment the CLI runs in (global install, workspace dependency, or cached `npx` package).
 
 Run `npx @xmcp-dev/cli generate` to produce the typed client files.
+
+### Optional CLI flags
+
+- `-c, --clients <path>`: Custom path to `clients.ts` (default `src/clients.ts`).
+- `-o, --out <path>`: Output directory (default `src/generated`).
 
 ## Generated Output
 
@@ -58,12 +66,11 @@ An index file (`client.index.ts`) is always generated with a unified `generatedC
 ```ts
 import { generatedClients } from "./generated/client.index";
 
-await generatedClients.local.greet({ name: "World" });
-await generatedClients.production.randomNumber();
+await generatedClients.client1.greet({ name: "World" });
+await generatedClients.client2.randomNumber();
 ```
 
 ## Caveats
 
-- **`--url` overrides `clients.ts`** — When provided, only a single HTTP client is generated using the specified URL, ignoring all entries in the config file.
 - **Server/process must be available** — The CLI connects over HTTP or spawns the STDIO package to fetch tool definitions. Ensure the remote server is reachable or the npm package is installed and executable in your environment.
-- **`MCP_URL` env var** — Falls back to this if no `--url` or `clients.ts` is found.
+- **clients.ts required** — The CLI generates clients only from the definitions you provide (or the path you pass with `--clients`).

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import pkg, { CustomHeaders } from "xmcp";
+import pkg from "xmcp";
 const { createHTTPClient, createSTDIOClient, disconnectSTDIOClient } = pkg;
 import {
   loadClientDefinitions,
@@ -15,7 +15,6 @@ import {
 } from "../utils/templates.js";
 
 export interface GenerateOptions {
-  url?: string;
   out?: string;
   clientsFile?: string;
 }
@@ -29,7 +28,7 @@ export async function runGenerate(options: GenerateOptions = {}) {
     DEFAULT_CLIENTS_FILE
   );
   const clientDefinitions = loadedClients?.definitions ?? [];
-  const targets = resolveTargets(options.url, clientDefinitions);
+  const targets = resolveTargets(clientDefinitions);
 
   logDetectedClients(loadedClients, clientDefinitions);
 
@@ -96,27 +95,11 @@ export async function runGenerate(options: GenerateOptions = {}) {
 }
 
 function resolveTargets(
-  explicitUrl: string | undefined,
   clientDefinitions: ClientDefinition[]
 ): ClientDefinition[] {
-  if (explicitUrl || process.env.MCP_URL) {
-    const resolvedUrl = explicitUrl ?? process.env.MCP_URL!;
-    return [
-      {
-        type: "http",
-        name: clientDefinitions[0]?.name ?? "client",
-        url: resolvedUrl,
-        headers:
-          clientDefinitions[0]?.type === "http"
-            ? clientDefinitions[0].headers
-            : undefined,
-      },
-    ];
-  }
-
   if (clientDefinitions.length === 0) {
     throw new Error(
-      "Unable to determine MCP URL. Provide --url, set MCP_URL, or add entries to clients.ts."
+      "No clients found. Add entries to clients.ts (or point --clients to your config)."
     );
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,6 @@ Commands:
   generate            Generate a typed remote tool client file
 
 Options:
-  -u, --url <url>     MCP server URL (overrides clients.ts)
   -o, --out <path>    Output directory (default: src/generated)
   -c, --clients <path>  Path to clients config (default: src/clients.ts)
   -h, --help          Show this help message
@@ -39,10 +38,6 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "-h":
       case "--help":
         helpRequested = true;
-        break;
-      case "-u":
-      case "--url":
-        options.url = args[++i];
         break;
       case "-o":
       case "--out":
@@ -84,7 +79,6 @@ async function main() {
   }
 
   await runGenerate({
-    url: typeof options.url === "string" ? options.url : undefined,
     out: typeof options.out === "string" ? options.out : undefined,
     clientsFile:
       typeof options.clients === "string" ? options.clients : undefined,

--- a/packages/xmcp/src/client/utils.ts
+++ b/packages/xmcp/src/client/utils.ts
@@ -1,7 +1,3 @@
-import {
-  isJSONRPCRequest,
-  JSONRPCMessage,
-} from "@modelcontextprotocol/sdk/types";
 import { JsonSchemaType } from "./types";
 
 export function resolveRef(
@@ -43,7 +39,7 @@ export function resolveRef(
 }
 
 export function normalizeUnionType(schema: JsonSchemaType): JsonSchemaType {
-  // Handle anyOf with exactly string and null (FastMCP pattern)
+  // Handle anyOf with exactly string and null
   if (
     schema.anyOf &&
     schema.anyOf.length === 2 &&
@@ -53,7 +49,7 @@ export function normalizeUnionType(schema: JsonSchemaType): JsonSchemaType {
     return { ...schema, type: "string", anyOf: undefined, nullable: true };
   }
 
-  // Handle anyOf with exactly boolean and null (FastMCP pattern)
+  // Handle anyOf with exactly boolean and null
   if (
     schema.anyOf &&
     schema.anyOf.length === 2 &&
@@ -63,7 +59,7 @@ export function normalizeUnionType(schema: JsonSchemaType): JsonSchemaType {
     return { ...schema, type: "boolean", anyOf: undefined, nullable: true };
   }
 
-  // Handle anyOf with exactly number and null (FastMCP pattern)
+  // Handle anyOf with exactly number and null
   if (
     schema.anyOf &&
     schema.anyOf.length === 2 &&
@@ -73,7 +69,7 @@ export function normalizeUnionType(schema: JsonSchemaType): JsonSchemaType {
     return { ...schema, type: "number", anyOf: undefined, nullable: true };
   }
 
-  // Handle anyOf with exactly integer and null (FastMCP pattern)
+  // Handle anyOf with exactly integer and null
   if (
     schema.anyOf &&
     schema.anyOf.length === 2 &&
@@ -83,7 +79,7 @@ export function normalizeUnionType(schema: JsonSchemaType): JsonSchemaType {
     return { ...schema, type: "integer", anyOf: undefined, nullable: true };
   }
 
-  // Handle anyOf with exactly array and null (FastMCP pattern)
+  // Handle anyOf with exactly array and null
   if (
     schema.anyOf &&
     schema.anyOf.length === 2 &&


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes URL flag and MCP_URL fallback, making clients.ts the single source of client definitions; updates CLI help/logic and README, plus minor utils cleanup.
> 
> - **CLI**:
>   - Remove `--url` flag and `MCP_URL` fallback; `clients.ts` is now required for targets.
>   - Simplify `resolveTargets()` and error message; stop passing `url` through the command layer.
>   - Update help text and argument parsing to only support `--out` and `--clients`.
> - **Docs**:
>   - Rewrite `packages/cli/README.md` to focus on `clients.ts`, add STDIO examples (`firecrawl`, `context7`), clarify env passthrough, and list optional flags.
>   - Update generated client usage examples and caveats; remove references to `--url`/`MCP_URL`.
> - **Library**:
>   - Clean up `xmcp` client utils by removing unused imports and simplifying comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b86491f9e942edfeddd6f6134bfcb7dfd0ea114b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->