### PR TITLE
tool schema with compatible zod versions

### DIFF
--- a/packages/xmcp/src/types/tool.ts
+++ b/packages/xmcp/src/types/tool.ts
@@ -101,7 +101,7 @@ export interface ToolExtraArguments {
   ) => Promise<z.infer<U>>;
 }
 
-export type InferSchema<T extends ToolSchema> = {
+export type InferSchema<T extends Record<string, unknown>> = {
   [K in keyof T]: T[K] extends z.ZodTypeAny
     ? z.infer<T[K]>
     : T[K] extends ZodTypeV4<unknown>


### PR DESCRIPTION
pick the right infer based on zod version
- property is a v3 type (z.ZodTypeAny from zod/v3): uses z.infer<T[K]>
- property is a v4 Zod type (ZodTypeV4<unknown> from zod - which is 4 by default), it uses v4’s inferV4<T[K]>