### PR TITLE
feat: introducing customHome config option

### DIFF
--- a/examples/template-config/xmcp.config.ts
+++ b/examples/template-config/xmcp.config.ts
@@ -5,6 +5,13 @@ const config: XmcpConfig = {
   template: {
     name: "Custom xmcp server",
     description: "You can modify this description in the xmcp.config.ts file.",
+
+    // Custom home page - can be inline HTML or a file path
+    // Option 1: Inline HTML string
+    // homePage: "<html><body><h1>Welcome to my MCP server!</h1></body></html>",
+
+    // Option 2: Path to an HTML file (relative to project root)
+    // homePage: "src/home.html",
   },
 };
 

--- a/packages/xmcp/src/compiler/config/injection.ts
+++ b/packages/xmcp/src/compiler/config/injection.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
 import {
   getResolvedHttpConfig,
   getResolvedCorsConfig,
@@ -101,8 +103,23 @@ export type StdioVariables = ReturnType<typeof injectStdioVariables>;
 export function injectTemplateVariables(userConfig: XmcpConfigOutputSchema) {
   const resolvedConfig = getResolvedTemplateConfig(userConfig);
 
+  let homePage = resolvedConfig.homePage;
+
+  if (homePage && homePage.endsWith(".html")) {
+    const filePath = resolve(process.cwd(), homePage);
+    if (existsSync(filePath)) {
+      homePage = readFileSync(filePath, "utf-8");
+    } else {
+      console.warn(`[xmcp] homePage file not found: ${filePath}`);
+      homePage = undefined;
+    }
+  }
+
   return {
-    TEMPLATE_CONFIG: JSON.stringify(resolvedConfig),
+    TEMPLATE_CONFIG: JSON.stringify({
+      ...resolvedConfig,
+      homePage,
+    }),
   };
 }
 

--- a/packages/xmcp/src/compiler/config/schemas/template.ts
+++ b/packages/xmcp/src/compiler/config/schemas/template.ts
@@ -3,12 +3,33 @@ import { z } from "zod/v3";
 // ------------------------------------------------------------
 // Template config schema
 // ------------------------------------------------------------
+
 // Base schema with defaults - used for parsing with defaults applied
 const templateConfigBaseSchema = z.object({
+  /** The display name of the MCP server shown on the home page */
   name: z.string().default("xmcp server"),
+  /** A description of the MCP server shown on the home page */
   description: z
     .string()
     .default("This MCP server was bootstrapped with xmcp."),
+  /**
+   * Custom home page content for the `/` endpoint.
+   *
+   * Can be either:
+   * - A static HTML string
+   * - A path to an HTML file (must end with `.html`, relative to project root)
+   *
+   * When not provided, the default xmcp home page template is used.
+   *
+   * @example
+   * // Inline HTML
+   * homePage: "<html><body><h1>Welcome!</h1></body></html>"
+   *
+   * @example
+   * // File path
+   * homePage: "src/home.html"
+   */
+  homePage: z.string().optional(),
 });
 
 // Input schema - all fields optional for partial configs

--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -346,6 +346,13 @@ export class StatelessStreamableHTTPTransport {
     });
 
     this.app.get("/", (_req: Request, res: Response) => {
+      const customHomePage = this.options.template?.homePage;
+
+      if (customHomePage) {
+        res.send(customHomePage);
+        return;
+      }
+
       res.send(
         homeTemplate(
           this.endpoint,


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**
>
> ⚠️ _If you are updating documentation or the site, please target the **main** branch instead of `canary`._

## Summary

**Context**: 
While the default landing page works well for many setups, some projects need complete flexibility — from replacing it with a fully custom HTML page to simply serving a minimal string.

**Propossal**:
Adds a `template.homePage` configuration option that allows customizing the home page (`/`) served by the HTTP transport. The option accepts:

* A static HTML string
* A path to an HTML file (must end with .html, relative to project root)

When using a file path, the contents are read at build time and injected into the bundle.

## Type of Change

- [ ] Bug fixing
- [x] Adding a feature
- [ ] Improving documentation
- [x] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [x] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [ ] Documentation
- [x] Examples

## Screenshots/Examples

Sample `xmcp.config.ts`
```
import { type XmcpConfig } from "xmcp";

const config: XmcpConfig = {
  http: true,
  // Customize the root HTML page served in dev/start
  template: {
    name: "XMCP App",
    description: "Operational tools and MCP endpoints for our team.",
    homePage: "src/home.html",
  },
  paths: {
    tools: "./src/tools",
    prompts: "./src/prompts",
    resources: "./src/resources",
  },
};

export default config;
````

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables a customizable root HTML page for HTTP servers.
> 
> - Adds `homePage` to `template` config schema; accepts inline HTML or a path ending in `.html`
> - Compiler injects `template.homePage`, reading file contents at build time when a path is provided (warns if missing)
> - HTTP transport serves `options.template.homePage` at `/` when set; otherwise falls back to default template
> - Updates example `xmcp.config.ts` to demonstrate `homePage` usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf12c55bd2b2dfc52e8a5b7b1987a6084c5498a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->