### PR TITLE
fix: include tsx files in tsconfig for default templates

### DIFF
--- a/packages/create-xmcp-app/templates/gpt-apps/default/tsconfig.json
+++ b/packages/create-xmcp-app/templates/gpt-apps/default/tsconfig.json
@@ -2,10 +2,11 @@
   "compilerOptions": {
     "target": "es2017",
     "module": "commonjs",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["xmcp-env.d.ts", "src/**/*.ts"]
+  "include": ["xmcp-env.d.ts", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/create-xmcp-app/templates/mcp-apps/default/tsconfig.json
+++ b/packages/create-xmcp-app/templates/mcp-apps/default/tsconfig.json
@@ -2,10 +2,11 @@
   "compilerOptions": {
     "target": "es2017",
     "module": "commonjs",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["xmcp-env.d.ts", "src/**/*.ts"]
+  "include": ["xmcp-env.d.ts", "src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**

## Summary

Fixed the default templates for both GPT apps and MCP apps to properly include `.tsx` files in their TypeScript configuration. These templates contained `.tsx` files but their `tsconfig.json` was only including `.ts` files, which could cause type checking issues. Added the `jsx` compiler option and `.tsx` file pattern to match the tailwind template configuration.

## Type of Change

- [x] Bug fixing

## Affected Packages

- [x] `create-xmcp-app`