### PR TITLE
add globals.css auto-detection and update docs

### DIFF
--- a/apps/website/content/docs/core-concepts/css.mdx
+++ b/apps/website/content/docs/core-concepts/css.mdx
@@ -9,6 +9,10 @@ If you're using [ChatGPT widgets](/docs/core-concepts/tools#openai-metadata) or 
 - [CSS](#css)
 - [CSS Modules](#css-modules)
 
+<Callout type="info">
+xmcp automatically detects and imports a `globals.css` file if it exists in `globals.css`, `src/globals.css`, or `src/tools/globals.css` (in priority order). You don't need to manually import it in every tool.
+</Callout>
+
 ## Tailwind CSS
 
 A CSS framework that provides utility classes like `flex`, `pt-4`, `text-center`, and `rotate-90`. You use these classes directly in your component to build layouts and designs.
@@ -51,17 +55,16 @@ export default {
 }
 ```
 
-Create a global CSS file (e.g., `globals.css`) and import Tailwind:
+Create a `globals.css` file in your project root (or `src/globals.css`) and import Tailwind:
 
 ```css
 @import 'tailwindcss';
 ```
 
-Import the CSS file in your tool file:
+Now you can use Tailwind classes in your tools:
 
 ```tsx
 import type { ToolMetadata } from "xmcp";
-import "./globals.css";
 
 export const metadata: ToolMetadata = {
   name: "greet",
@@ -81,6 +84,8 @@ export default function handler() {
 
 Write standard CSS to style your components without any framework or tooling.
 
+Create a `globals.css` file:
+
 ```css
 .title {
   font-size: 2rem;
@@ -88,9 +93,10 @@ Write standard CSS to style your components without any framework or tooling.
 }
 ```
 
+Use the styles in your tool:
+
 ```tsx
 import type { ToolMetadata } from "xmcp";
-import "./globals.css";
 
 export const metadata: ToolMetadata = {
   name: "greet",

--- a/examples/open-ai-react-tailwind/src/tools/counter.tsx
+++ b/examples/open-ai-react-tailwind/src/tools/counter.tsx
@@ -1,7 +1,6 @@
 import { InferSchema, type ToolMetadata } from "xmcp";
 import { useState } from "react";
 import { z } from "zod";
-import "../../globals.css";
 
 export const metadata: ToolMetadata = {
   name: "counter",

--- a/examples/open-ai-react-tailwind/src/tools/weather.tsx
+++ b/examples/open-ai-react-tailwind/src/tools/weather.tsx
@@ -1,6 +1,5 @@
 import { type ToolMetadata } from "xmcp";
 import { useState, useEffect } from "react";
-import "../../globals.css";
 
 export const metadata: ToolMetadata = {
   name: "weather",

--- a/packages/xmcp/src/compiler/client/component-compiler.ts
+++ b/packages/xmcp/src/compiler/client/component-compiler.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { rspack } from "@rspack/core";
 import type { RspackOptions } from "@rspack/core";
-import { hasPostCSSConfig } from "../utils/config-detection";
+import { findGlobalsCss, hasPostCSSConfig } from "../utils/config-detection";
 
 interface CompileOptions {
   entries: Map<string, string>;
@@ -103,9 +103,15 @@ export class ClientComponentCompiler {
   }
 
   private createEntryModule(componentPath: string): string {
+    const globalsCssPath = findGlobalsCss();
+    const globalsCssImport = globalsCssPath
+      ? `import ${JSON.stringify(globalsCssPath)};`
+      : "";
+
     return `
   import React from "react";
   import { createRoot } from "react-dom/client";
+  ${globalsCssImport}
   import Component from ${JSON.stringify(componentPath)};
 
   const el = document.getElementById("root");

--- a/packages/xmcp/src/compiler/utils/config-detection.ts
+++ b/packages/xmcp/src/compiler/utils/config-detection.ts
@@ -14,3 +14,21 @@ export function hasPostCSSConfig(): boolean {
 
   return configFiles.some((file) => existsSync(join(cwd, file)));
 }
+
+export function findGlobalsCss(): string | null {
+  const cwd = process.cwd();
+  const searchPaths = [
+    "globals.css",
+    "src/globals.css",
+    "src/tools/globals.css",
+  ];
+
+  for (const relativePath of searchPaths) {
+    const absolutePath = join(cwd, relativePath);
+    if (existsSync(absolutePath)) {
+      return absolutePath;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**
>
> ⚠️ _If you are updating documentation or the site, please target the **main** branch instead of `canary`._

## Summary
adds automatic detection and injection of globals.css from root, src, or src/tools dirs

## Type of Change

- [ ] Bug fixing
- [x] Adding a feature
- [x] Improving documentation
- [x] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [x] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [x] Documentation
- [x] Examples

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->

## Related Issues

<!-- Link any related issues: "Fixes #123" or "Closes #456" -->
