### PR TITLE
downloadTarStream handle download status

### DIFF
--- a/packages/create-xmcp-app/src/helpers/examples.ts
+++ b/packages/create-xmcp-app/src/helpers/examples.ts
@@ -49,8 +49,11 @@ export function hasRepo(filePath: string): Promise<boolean> {
 async function downloadTarStream(url: string) {
   const res = await fetch(url);
 
-  if (!res.body) {
-    throw new Error(`Failed to download: ${url}`);
+  if (!res.ok || !res.body) {
+    const statusText = res.statusText || "Unknown error";
+    throw new Error(
+      `Failed to download: ${url} (status ${res.status} ${statusText})`
+    );
   }
 
   return Readable.fromWeb(res.body as import("stream/web").ReadableStream);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves robustness of template download.
> 
> - Updates `downloadTarStream` to check `res.ok` in addition to `res.body` and throw a detailed error including HTTP status code/text
> - Affects `downloadAndExtractRepo` flow by providing clearer failures when GitHub tarball fetches are unsuccessful
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a12f36c031cd34ab169e6c68aa74b4596563f0db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->