### PR TITLE
add safety checks to the --example path

### DIFF
--- a/packages/create-xmcp-app/src/index.ts
+++ b/packages/create-xmcp-app/src/index.ts
@@ -65,7 +65,25 @@ const program = new Command()
       const targetPath = projectDir
         ? path.resolve(process.cwd(), projectDir)
         : process.cwd();
-      fs.ensureDirSync(targetPath);
+      const targetName = path.basename(targetPath);
+
+      if (fs.existsSync(targetPath)) {
+        const stats = fs.statSync(targetPath);
+        if (!stats.isDirectory()) {
+          console.error(
+            chalk.red(`Error: ${targetName} exists but is not a directory.`)
+          );
+          process.exit(1);
+        }
+
+        if (!isFolderEmpty(targetPath, targetName)) {
+          console.error(chalk.red(`The directory ${targetPath} is not empty.`));
+          process.exit(1);
+        }
+      } else {
+        fs.ensureDirSync(targetPath);
+      }
+
       await downloadAndExtractExample(targetPath, options.example);
 
       console.log();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds guardrails when using `--example` in `packages/create-xmcp-app/src/index.ts`.
> 
> - Verifies the resolved target path is a directory; errors if it exists as a non-directory
> - Ensures the directory is empty via `isFolderEmpty`; errors if not empty
> - Creates the directory only if it does not exist
> - Proceeds to `downloadAndExtractExample` only after the above checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2883699d47103b665a7dca8eb403bd7436cf32d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->