### PR TITLE
exclude .config and .vscode directories from examples list

### DIFF
--- a/packages/create-xmcp-app/src/helpers/examples.ts
+++ b/packages/create-xmcp-app/src/helpers/examples.ts
@@ -146,7 +146,12 @@ async function getExamples(): Promise<string[]> {
 
     const items: GitHubContentItem[] = await res.json();
     const names = items
-      .filter((item) => item.type === "dir")
+      .filter(
+        (item) =>
+          item.type === "dir" &&
+          item.name !== ".config" &&
+          item.name !== ".vscode"
+      )
       .map((item) => item.name)
       .filter(Boolean);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Filters hidden metadata folders from example discovery to avoid listing non-example directories.
> 
> - Updates `getExamples` to exclude `.config` and `.vscode` when fetching repository contents so `listExamples` only shows actual example templates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96b81f700d00cd4ae6ab25d1e114610e23ed27e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->