### PR TITLE
feat(better-auth): add plugins option for custom OAuth providers

### DIFF
--- a/packages/plugins/better-auth/src/types.ts
+++ b/packages/plugins/better-auth/src/types.ts
@@ -1,3 +1,4 @@
+import type { BetterAuthPlugin } from "better-auth";
 import { Database } from "./databases.js";
 
 // Extracted from better-auth types
@@ -102,10 +103,46 @@ export type BetterAuthConfig = {
   baseURL: string;
   secret: string;
   providers?: {
-    emailAndPassword: EmailAndPassword;
+    emailAndPassword?: EmailAndPassword;
     google?: {
       clientId: string;
       clientSecret: string;
     };
   };
+  /**
+   * Custom Better Auth plugins to include.
+   *
+   * Use this to add your own OAuth providers (via genericOAuth) or other
+   * Better Auth plugins while keeping the sign-in UI, middleware, and
+   * session management provided by this wrapper.
+   *
+   * The MCP plugin is always included automatically.
+   *
+   * @example
+   * ```typescript
+   * import { genericOAuth } from 'better-auth/plugins/generic-oauth';
+   *
+   * // Create custom OAuth provider with full control
+   * const googleOAuth = genericOAuth({
+   *   config: [{
+   *     providerId: 'google',
+   *     clientId: process.env.GOOGLE_CLIENT_ID,
+   *     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+   *     authorizationUrl: 'https://sso-proxy.example.com/proxy/https://accounts.google.com/o/oauth2/v2/auth',
+   *     tokenUrl: 'https://oauth2.googleapis.com/token',
+   *     userInfoUrl: 'https://openidconnect.googleapis.com/v1/userinfo',
+   *     scopes: ['openid', 'email', 'profile'],
+   *     pkce: true,
+   *   }],
+   * });
+   *
+   * betterAuthProvider({
+   *   database: pool,
+   *   baseURL: '...',
+   *   secret: '...',
+   *   plugins: [googleOAuth],
+   * });
+   * ```
+   */
+  plugins?: BetterAuthPlugin[];
 };

--- a/packages/plugins/better-auth/src/utils.ts
+++ b/packages/plugins/better-auth/src/utils.ts
@@ -6,6 +6,10 @@ export interface ResponseConfig {
     google?: {
       enabled: boolean;
     };
+    /** Indicates custom plugins are configured (e.g., genericOAuth) */
+    customPlugins?: {
+      enabled: boolean;
+    };
   };
 }
 


### PR DESCRIPTION
edit: Please disregard this PR, it's not ready yet and was opened by mistake - sorry for the noise!

## Summary

This PR adds a `plugins` option to `betterAuthProvider` that allows consumers to pass their own Better Auth plugins (like `genericOAuth`) while keeping all the conveniences of this wrapper:

- Sign-in UI
- Session middleware for `/mcp` routes
- Session management via `getBetterAuthSession()`

## Use Cases

- **Custom authorization URLs** (e.g., SSO proxy for multiple environments sharing one OAuth app)
- **OAuth providers not built into Better Auth**
- **Advanced OAuth configuration** (scopes, PKCE, profile mapping)

## Example Usage

```typescript
import { betterAuthProvider } from '@xmcp-dev/better-auth';
import { genericOAuth } from 'better-auth/plugins/generic-oauth';

const googleOAuth = genericOAuth({
  config: [{
    providerId: 'google',
    clientId: process.env.GOOGLE_CLIENT_ID,
    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
    authorizationUrl: 'https://sso-proxy.example.com/proxy/https://accounts.google.com/o/oauth2/v2/auth',
    tokenUrl: 'https://oauth2.googleapis.com/token',
    userInfoUrl: 'https://openidconnect.googleapis.com/v1/userinfo',
    scopes: ['openid', 'email', 'profile'],
    pkce: true,
  }],
});

export default betterAuthProvider({
  database: pool,
  baseURL: process.env.BETTER_AUTH_BASE_URL,
  secret: process.env.BETTER_AUTH_SECRET,
  plugins: [googleOAuth],
});
```

## Changes

- Added `plugins?: BetterAuthPlugin[]` to `BetterAuthConfig` type
- Modified `getBetterAuthInstance` to include custom plugins alongside MCP plugin
- Updated router to handle OAuth callbacks for any provider (`/auth/callback/:provider`)
- Updated README with documentation and examples

## Notes

- The MCP plugin is always included automatically
- When custom plugins are provided, the built-in `providers.google` is skipped (assumes custom plugin handles OAuth)