### PR TITLE
Sstateless auth

### DIFF
--- a/packages/xmcp/src/runtime/transports/http/base-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/base-streamable-http.ts
@@ -1,4 +1,7 @@
 import { TemplateConfig } from "@/compiler/config/schemas";
+import { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types";
+import { Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import { MessageExtraInfo } from "@modelcontextprotocol/sdk/types";
 import { IncomingMessage, ServerResponse } from "http";
 
 export interface HttpTransportOptions {
@@ -21,14 +24,14 @@ export interface JsonRpcMessage {
 
 // shared between stateless and stateful transports
 // just to paint the same interface
-export abstract class BaseHttpServerTransport {
+export abstract class BaseHttpServerTransport implements Transport {
   // If we ever want to have more control over the transport, we can add onclose, onerror, onmessage here
   // or interceptors for requests and responses
   // e.g. to add a custom header to the response or a middleware layer!
 
   // to do add the logging methods like log and error
   // MCP SDK transport interface
-  onmessage?: (message: JsonRpcMessage) => void;
+  onmessage?: (message: JsonRpcMessage, extra?: MessageExtraInfo) => void;
   onerror?: (error: Error) => void;
   onclose?: () => void;
 
@@ -36,7 +39,7 @@ export abstract class BaseHttpServerTransport {
   abstract close(): Promise<void>;
   abstract send(message: JsonRpcMessage): Promise<void>;
   abstract handleRequest(
-    req: IncomingMessage,
+    req: IncomingMessage & { auth?: AuthInfo },
     res: ServerResponse,
     parsedBody?: unknown
   ): Promise<void>;

--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -18,6 +18,7 @@ import { cors } from "./cors";
 import { Provider } from "@/runtime/middlewares/utils";
 import { httpRequestContextProvider } from "@/runtime/contexts/http-request-context";
 import { CorsConfig, corsConfigSchema } from "@/compiler/config/schemas";
+import { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types";
 
 // Global type declarations for tool name context
 declare global {
@@ -121,7 +122,7 @@ export class StatelessHttpServerTransport extends BaseHttpServerTransport {
   }
 
   async handleRequest(
-    req: IncomingMessage,
+    req: IncomingMessage & { auth?: AuthInfo },
     res: ServerResponse,
     parsedBody?: unknown
   ): Promise<void> {
@@ -144,7 +145,7 @@ export class StatelessHttpServerTransport extends BaseHttpServerTransport {
   }
 
   private async handlePOST(
-    req: IncomingMessage,
+    req: IncomingMessage & { auth?: AuthInfo },
     res: ServerResponse,
     parsedBody?: unknown
   ): Promise<void> {
@@ -237,10 +238,12 @@ export class StatelessHttpServerTransport extends BaseHttpServerTransport {
         this._requestToCollectorMapping.set(requestId, collectorId);
       }
 
+      const authInfo: AuthInfo | undefined = req.auth;
+
       // MCP SDK transport interface mandatory
       for (const message of messages) {
         if (this.onmessage) {
-          this.onmessage(message);
+          this.onmessage(message, { authInfo });
         }
       }
     } catch (error) {


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**
>
> ⚠️ _If you are updating documentation or the site, please target the **main** branch instead of `canary`._

## Summary

`StatelessStreamableHTTPTransport` doesn't support auth, bring it up to date with https://github.com/modelcontextprotocol/typescript-sdk/pull/399 so that auth works in the next.js adapter. 

This makes sure that `extra.authInfo` is passed to the handler if `req.auth` is populated. 

## Type of Change

- [ ] Bug fixing
- [*] Adding a feature
- [ ] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [*] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [ ] Documentation
- [ ] Examples

## Screenshots/Examples



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds stateless auth propagation and aligns HTTP transport with MCP SDK.
> 
> - `BaseHttpServerTransport` now implements `Transport`; `onmessage` accepts `MessageExtraInfo` and HTTP `handleRequest` expects `IncomingMessage & { auth?: AuthInfo }`
> - `StatelessHttpServerTransport` reads `req.auth` and forwards as `extra.authInfo` via `onmessage(message, { authInfo })` for all messages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 757ac6bbcf22b09be32e808b2bfe7a5fea9aa72d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->