### PR TITLE
Fix broken documentation links in middlewares page

### DIFF
--- a/apps/website/content/docs/core-concepts/middlewares.mdx
+++ b/apps/website/content/docs/core-concepts/middlewares.mdx
@@ -29,8 +29,8 @@ export default middleware;
 
 <Callout variant="info">
   xmcp provides built-in middlewares for common tasks like [API key
-  authentication](../../authentication/api-key) and [JSON web token
-  authentication](../../authentication/jwt).
+  authentication](/docs/authentication/api-key) and [JSON web token
+  authentication](/docs/authentication/jwt).
 </Callout>
 
 ## Chaining middlewares


### PR DESCRIPTION
## Summary
Fixed broken documentation links in the middlewares page. Changed relative paths to absolute paths for API key and JWT authentication links to resolve 404 errors.

## Type of Change
- [x] Improving documentation

## Affected Packages
- [x] Documentation

## Related Issues
Fixes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)