### PR TITLE
Fix broken documentation links in middlewares page

### DIFF
--- a/apps/website/content/docs/core-concepts/middlewares.mdx
+++ b/apps/website/content/docs/core-concepts/middlewares.mdx
@@ -29,8 +29,8 @@ export default middleware;
 
 <Callout variant="info">
   xmcp provides built-in middlewares for common tasks like [API key
-  authentication](../../authentication/api-key) and [JSON web token
-  authentication](../../authentication/jwt).
+  authentication](/docs/authentication/api-key) and [JSON web token
+  authentication](/docs/authentication/jwt).
 </Callout>
 
 ## Chaining middlewares


### PR DESCRIPTION
Changed relative paths to absolute paths for API key and JWT authentication links to resolve 404 errors.

> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**
>
> ⚠️ _If you are updating documentation or the site, please target the **main** branch instead of `canary`._

## Summary

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fixing
- [ ] Adding a feature
- [ ] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [ ] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [ ] Documentation
- [ ] Examples

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->

## Related Issues

<!-- Link any related issues: "Fixes #123" or "Closes #456" -->
