### PR TITLE
Remove duplicate MCP Apps metadata section

### DIFF
--- a/apps/website/content/docs/core-concepts/tools.mdx
+++ b/apps/website/content/docs/core-concepts/tools.mdx
@@ -252,37 +252,6 @@ export const metadata: ToolMetadata = {
 - `domain` - Optional dedicated subdomain for the widget's sandbox origin
 - `prefersBorder` - Request visible border + background (`true`/`false`/omitted)
 
-### MCP Apps metadata
-
-<Callout variant="info">
-  Unlike OpenAI widgets, MCP Apps do not require specific metadata
-  configuration. Widgets work automatically without additional setup.
-</Callout>
-
-```typescript
-export const metadata: ToolMetadata = {
-  name: "show-analytics",
-  description: "Display analytics dashboard",
-  _meta: {
-    ui: {
-      csp: {
-        connectDomains: ["https://api.analytics.com"],
-        resourceDomains: ["https://cdn.analytics.com"],
-      },
-      domain: "https://analytics-widget.example.com",
-      prefersBorder: true,
-    },
-  },
-};
-```
-
-**Resource-specific properties:**
-
-- `csp.connectDomains` - Origins for fetch/XHR/WebSocket connections
-- `csp.resourceDomains` - Origins for images, scripts, stylesheets, fonts, media
-- `domain` - Optional dedicated subdomain for the widget's sandbox origin
-- `prefersBorder` - Request visible border + background (`true`/`false`/omitted)
-
 ## Handler Types
 
 Tools support three types of handlers, each suited for different use cases:


### PR DESCRIPTION
## Summary

Removed duplicate MCP Apps metadata section from tools documentation. The section was appearing twice consecutively with identical content.

## Type of Change

- [x] Improving documentation

## Affected Packages

- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)