### PR TITLE
Replace static bash code blocks with TerminalTabs component in integration docs

### DIFF
--- a/apps/website/content/docs/integrations/auth0.mdx
+++ b/apps/website/content/docs/integrations/auth0.mdx
@@ -10,9 +10,31 @@ description: "The Auth0 plugin provides authentication for your MCP server using
 
 Install the Auth0 plugin:
 
-```bash
-npm install @xmcp-dev/auth0
-```
+<TerminalTabs
+  tabs={[
+    {
+      label: "pnpm",
+      value: "pnpm",
+      content: "pnpm i @xmcp-dev/auth0",
+    },
+    {
+      label: "npm",
+      value: "npm",
+      content: "npm i @xmcp-dev/auth0",
+    },
+    {
+      label: "yarn",
+      value: "yarn",
+      content: "yarn add @xmcp-dev/auth0",
+    },
+    {
+      label: "bun",
+      value: "bun",
+      content: "bun add @xmcp-dev/auth0",
+    },
+  ]}
+  defaultTab="pnpm"
+/>
 
 ## Auth0 Tenant Setup
 

--- a/apps/website/content/docs/integrations/better-auth.mdx
+++ b/apps/website/content/docs/integrations/better-auth.mdx
@@ -18,10 +18,31 @@ The Better Auth plugin provides comprehensive authentication for your xmcp serve
 
 Install the Better Auth plugin and PostgreSQL dependencies:
 
-```bash
-npm install @xmcp-dev/better-auth pg
-npm install -D @types/pg
-```
+<TerminalTabs
+  tabs={[
+    {
+      label: "pnpm",
+      value: "pnpm",
+      content: "pnpm i @xmcp-dev/better-auth pg\npnpm i -D @types/pg",
+    },
+    {
+      label: "npm",
+      value: "npm",
+      content: "npm i @xmcp-dev/better-auth pg\nnpm i -D @types/pg",
+    },
+    {
+      label: "yarn",
+      value: "yarn",
+      content: "yarn add @xmcp-dev/better-auth pg\nyarn add -D @types/pg",
+    },
+    {
+      label: "bun",
+      value: "bun",
+      content: "bun add @xmcp-dev/better-auth pg\nbun add -D @types/pg",
+    },
+  ]}
+  defaultTab="pnpm"
+/>
 
 ## Database Setup
 

--- a/apps/website/content/docs/integrations/clerk.mdx
+++ b/apps/website/content/docs/integrations/clerk.mdx
@@ -10,9 +10,31 @@ description: "The Clerk plugin provides authentication for your MCP server using
 
 Install the Clerk plugin:
 
-```bash
-npm install @xmcp-dev/clerk
-```
+<TerminalTabs
+  tabs={[
+    {
+      label: "pnpm",
+      value: "pnpm",
+      content: "pnpm i @xmcp-dev/clerk",
+    },
+    {
+      label: "npm",
+      value: "npm",
+      content: "npm i @xmcp-dev/clerk",
+    },
+    {
+      label: "yarn",
+      value: "yarn",
+      content: "yarn add @xmcp-dev/clerk",
+    },
+    {
+      label: "bun",
+      value: "bun",
+      content: "bun add @xmcp-dev/clerk",
+    },
+  ]}
+  defaultTab="pnpm"
+/>
 
 ## Clerk Setup
 

--- a/apps/website/content/docs/integrations/polar.mdx
+++ b/apps/website/content/docs/integrations/polar.mdx
@@ -14,9 +14,31 @@ The Polar plugin enables you to add paywalls with license key validation and tra
 
 Install the Polar plugin:
 
-```bash
-npm install @xmcp-dev/polar
-```
+<TerminalTabs
+  tabs={[
+    {
+      label: "pnpm",
+      value: "pnpm",
+      content: "pnpm i @xmcp-dev/polar",
+    },
+    {
+      label: "npm",
+      value: "npm",
+      content: "npm i @xmcp-dev/polar",
+    },
+    {
+      label: "yarn",
+      value: "yarn",
+      content: "yarn add @xmcp-dev/polar",
+    },
+    {
+      label: "bun",
+      value: "bun",
+      content: "bun add @xmcp-dev/polar",
+    },
+  ]}
+  defaultTab="pnpm"
+/>
 
 ## Polar Setup
 

--- a/apps/website/content/docs/integrations/workos.mdx
+++ b/apps/website/content/docs/integrations/workos.mdx
@@ -10,9 +10,31 @@ description: "The WorkOS plugin provides authentication for your mcp server usin
 
 Install the WorkOS plugin:
 
-```bash
-npm install @xmcp-dev/workos
-```
+<TerminalTabs
+  tabs={[
+    {
+      label: "pnpm",
+      value: "pnpm",
+      content: "pnpm i @xmcp-dev/workos",
+    },
+    {
+      label: "npm",
+      value: "npm",
+      content: "npm i @xmcp-dev/workos",
+    },
+    {
+      label: "yarn",
+      value: "yarn",
+      content: "yarn add @xmcp-dev/workos",
+    },
+    {
+      label: "bun",
+      value: "bun",
+      content: "bun add @xmcp-dev/workos",
+    },
+  ]}
+  defaultTab="pnpm"
+/>
 
 ## WorkOS Setup
 


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the \`canary\` branch. PRs to other branches may be closed or require retargeting.**
>
> ⚠️ _If you are updating documentation or the site, please target the **main** branch instead of \`canary\`._

## Summary

Update installation instructions across Auth0, Better Auth, Clerk, Polar, and WorkOS integration documentation to use the interactive TerminalTabs component. Provides installation commands for all supported package managers (pnpm, npm, yarn, bun).

## Type of Change

- [x] Improving documentation
- [x] Adding or updating examples

## Affected Packages

- [x] Documentation