### PR TITLE
Tool registration mutates

### DIFF
--- a/packages/xmcp/src/compiler/generate-tools-code.ts
+++ b/packages/xmcp/src/compiler/generate-tools-code.ts
@@ -33,7 +33,7 @@ export function generateToolsExportCode(): string {
 
 ${importStatements}
 
-/** 
+/**
  * Runtime-accessible tools function that works from any context.
  * Generated at build time - always up to date with discovered tools.
  * @returns {Promise<ToolRegistry>}
@@ -65,7 +65,7 @@ export async function getTools() {
         if (!("parse" in val) || typeof val.parse !== "function") return false;
         return true;
       });
-      
+
       if (isValidSchema) {
         toolSchema = schema;
       } else {
@@ -89,10 +89,8 @@ export async function getTools() {
       }
     }
 
-    // Make sure tools has annotations with a title
-    if (toolConfig.annotations === undefined) {
-      toolConfig.annotations = {};
-    }
+    // Make sure tools has annotations with a title — shallow copy to avoid mutating shared objects
+    toolConfig.annotations = { ...(toolConfig.annotations ?? {}) };
     if (toolConfig.annotations.title === undefined) {
       toolConfig.annotations.title = toolConfig.name;
     }

--- a/packages/xmcp/src/runtime/utils/tools.ts
+++ b/packages/xmcp/src/runtime/utils/tools.ts
@@ -30,6 +30,14 @@ export function pathToName(path: string): string {
   return fileName.replace(/\.[^/.]+$/, "");
 }
 
+/** Ensures toolConfig has its own annotations object with a title */
+export function ensureAnnotations(toolConfig: Pick<ToolMetadata, "name" | "annotations">): void {
+  toolConfig.annotations = { ...(toolConfig.annotations ?? {}) };
+  if (toolConfig.annotations.title === undefined) {
+    toolConfig.annotations.title = toolConfig.name;
+  }
+}
+
 /** Loads tools and injects them into the server */
 export function addToolsToServer(
   server: McpServer,
@@ -79,12 +87,7 @@ export function addToolsToServer(
     }
 
     // Make sure tools has annotations with a title
-    if (toolConfig.annotations === undefined) {
-      toolConfig.annotations = {};
-    }
-    if (toolConfig.annotations.title === undefined) {
-      toolConfig.annotations.title = toolConfig.name;
-    }
+    ensureAnnotations(toolConfig);
 
     if (toolConfig._meta === undefined) {
       toolConfig._meta = {};


### PR DESCRIPTION
The bug is about shared object references getting mutated during tool registration.

  When you define multiple tools that share the same annotations object:

```ts
const SHARED = { readOnlyHint: true };
const tool1 = { name: "list_components", annotations: SHARED };
const tool2 = { name: "get_icons", annotations: SHARED };
```

xmcp's registration code sets annotations.title directly on that object:

```ts
if (annotations.title === undefined) {
    annotations.title = toolConfig.name;  // mutates SHARED in place
}
```
  So when tool1 registers first, SHARED.title becomes "list_components". When tool2 registers, SHARED.title is no longer undefined, it's already "list_components" so the check skips it. Both tools end up with the title "list_components".
  
Closes #530 