### PR TITLE
feat: improve error handling for empty or malformed prompt and resource files

### DIFF
--- a/apps/website/content/docs/core-concepts/prompts.mdx
+++ b/apps/website/content/docs/core-concepts/prompts.mdx
@@ -101,3 +101,34 @@ The default export function that performs the actual work.
 - **Parameters**: Automatically typed from your schema using the built-in `InferSchema`.
 - **Returns**: MCP-compatible response with content type.
 - **Async**: Supports async operations for API calls, file I/O, etc.
+
+## Troubleshooting
+
+### Prompt Loading Errors
+
+When `xmcp` starts, it loads every file under your prompt directory.
+
+- Empty prompt files are skipped with a friendly warning
+- Files without a `default` export are skipped with a friendly warning
+- Real syntax or import errors still fail normally so you can see the full stack trace
+
+For example, if `src/prompts/review-code.ts` is empty, startup will log:
+
+```txt
+[xmcp] Failed to load prompt file: src/prompts/review-code.ts
+   -> File is empty.
+[xmcp] 1 prompt skipped due to empty files or missing default exports
+```
+
+If the file exists but does not export a default handler, startup will log:
+
+```txt
+[xmcp] Failed to load prompt file: src/prompts/review-code.ts
+   -> File does not export a default prompt handler.
+```
+
+<Callout variant="info">
+  Friendly handling is intentionally limited to empty files and missing default
+  exports. Invalid implementations and real import/syntax errors still surface
+  as normal runtime errors.
+</Callout>

--- a/apps/website/content/docs/core-concepts/resources.mdx
+++ b/apps/website/content/docs/core-concepts/resources.mdx
@@ -101,3 +101,34 @@ The default export function that performs the actual work.
 
 - **Parameters**: Automatically typed from your schema using the built-in `InferSchema`.
 - **Returns**: MCP-compatible response with content type.
+
+## Troubleshooting
+
+### Resource Loading Errors
+
+When `xmcp` starts, it loads every file under your resource directory.
+
+- Empty resource files are skipped with a friendly warning
+- Files without a `default` export are skipped with a friendly warning
+- Real syntax or import errors still fail normally so you can see the full stack trace
+
+For example, if `src/resources/draft.ts` is empty, startup will log:
+
+```txt
+[xmcp] Failed to load resource file: src/resources/draft.ts
+   -> File is empty.
+[xmcp] 1 resource skipped due to empty files or missing default exports
+```
+
+If the file exists but does not export a default handler, startup will log:
+
+```txt
+[xmcp] Failed to load resource file: src/resources/draft.ts
+   -> File does not export a default resource handler.
+```
+
+<Callout variant="info">
+  Friendly handling is intentionally limited to empty files and missing default
+  exports. Invalid implementations and real import/syntax errors still surface
+  as normal runtime errors.
+</Callout>

--- a/packages/xmcp/src/runtime/adapters/nextjs/handler/server-lifecycle.ts
+++ b/packages/xmcp/src/runtime/adapters/nextjs/handler/server-lifecycle.ts
@@ -38,10 +38,11 @@ export function setupCleanupHandlers(
  */
 export async function initializeMcpServer(): Promise<McpServer> {
   const [toolPromises, toolModules] = loadTools();
-  const [promptPromises, promptModules] = loadPrompts();
+  const promptModulesPromise = loadPrompts();
   const [resourcePromises, resourceModules] = loadResources();
 
-  await Promise.all([...toolPromises, ...promptPromises, ...resourcePromises]);
+  await Promise.all([...toolPromises, ...resourcePromises]);
+  const promptModules = await promptModulesPromise;
 
   const server = new McpServer(INJECTED_CONFIG);
 

--- a/packages/xmcp/src/runtime/adapters/nextjs/handler/server-lifecycle.ts
+++ b/packages/xmcp/src/runtime/adapters/nextjs/handler/server-lifecycle.ts
@@ -39,10 +39,13 @@ export function setupCleanupHandlers(
 export async function initializeMcpServer(): Promise<McpServer> {
   const [toolPromises, toolModules] = loadTools();
   const promptModulesPromise = loadPrompts();
-  const [resourcePromises, resourceModules] = loadResources();
+  const resourceModulesPromise = loadResources();
 
-  await Promise.all([...toolPromises, ...resourcePromises]);
-  const promptModules = await promptModulesPromise;
+  await Promise.all(toolPromises);
+  const [promptModules, resourceModules] = await Promise.all([
+    promptModulesPromise,
+    resourceModulesPromise,
+  ]);
 
   const server = new McpServer(INJECTED_CONFIG);
 

--- a/packages/xmcp/src/runtime/utils/prompt-loader.ts
+++ b/packages/xmcp/src/runtime/utils/prompt-loader.ts
@@ -1,0 +1,141 @@
+import type { PromptFile } from "./server";
+
+const EMPTY_PROMPT_FILE_MESSAGE = "File is empty.";
+const MISSING_DEFAULT_EXPORT_MESSAGE =
+  "File does not export a default prompt handler.";
+const INVALID_DEFAULT_EXPORT_MESSAGE =
+  "Default export must be a prompt handler function.";
+
+type PromptLoadIssue = {
+  path: string;
+  message: string;
+};
+
+function createPromptLoadIssue(path: string): PromptLoadIssue {
+  return {
+    path,
+    message: EMPTY_PROMPT_FILE_MESSAGE,
+  };
+}
+
+function createInvalidPromptImplementationError(path: string): Error {
+  return new Error(
+    `[xmcp] Invalid prompt file: ${path}\n   -> ${INVALID_DEFAULT_EXPORT_MESSAGE}`
+  );
+}
+
+function classifyPromptModule(
+  promptModule: unknown,
+  path: string
+): "empty" | "missing-default" | "valid" {
+  if (typeof promptModule !== "object" || promptModule === null) {
+    throw createInvalidPromptImplementationError(path);
+  }
+
+  const moduleRecord = promptModule as Record<string, unknown>;
+  const keys = Object.keys(moduleRecord);
+  if (keys.length === 0) {
+    return "empty";
+  }
+
+  if (!("default" in moduleRecord) || moduleRecord.default === undefined) {
+    return "missing-default";
+  }
+
+  if (typeof moduleRecord.default !== "function") {
+    throw createInvalidPromptImplementationError(path);
+  }
+
+  return "valid";
+}
+
+function toPromptFile(promptModule: unknown): PromptFile {
+  return promptModule as PromptFile;
+}
+
+export async function loadPromptModules(
+  loaders: Record<string, () => Promise<unknown>>
+) {
+  const promptModules = new Map<string, PromptFile>();
+  const skippedPrompts: PromptLoadIssue[] = [];
+
+  const results = await Promise.all(
+    Object.entries(loaders).map(async ([path, loadPrompt]) => {
+      const promptModule = await loadPrompt();
+      const classification = classifyPromptModule(promptModule, path);
+
+      if (classification === "empty") {
+        return {
+          skipped: true as const,
+          issue: createPromptLoadIssue(path),
+        };
+      }
+
+      if (classification === "missing-default") {
+        return {
+          skipped: true as const,
+          issue: {
+            path,
+            message: MISSING_DEFAULT_EXPORT_MESSAGE,
+          },
+        };
+      }
+
+      return {
+        skipped: false as const,
+        path,
+        promptModule: toPromptFile(promptModule),
+      };
+    })
+  );
+
+  for (const result of results) {
+    if (result.skipped) {
+      skippedPrompts.push(result.issue);
+      continue;
+    }
+
+    promptModules.set(result.path, result.promptModule);
+  }
+
+  return {
+    promptModules,
+    skippedPrompts,
+  };
+}
+
+function createPromptLoadIssueReporter(
+  logger: Pick<Console, "warn"> = console
+) {
+  let lastReportedSummaryKey = "";
+
+  return (skippedPrompts: PromptLoadIssue[]) => {
+    const summaryKey = skippedPrompts
+      .map(({ path, message }) => `${path}:${message}`)
+      .sort()
+      .join("|");
+
+    if (summaryKey === lastReportedSummaryKey) {
+      return;
+    }
+
+    lastReportedSummaryKey = summaryKey;
+
+    if (skippedPrompts.length === 0) {
+      return;
+    }
+
+    skippedPrompts.forEach(({ path, message }) => {
+      logger.warn(
+        `[xmcp] Failed to load prompt file: ${path}\n   -> ${message}`
+      );
+    });
+
+    const count = skippedPrompts.length;
+    logger.warn(
+      `[xmcp] ${count} prompt${count === 1 ? "" : "s"} skipped due to empty files or missing default exports`
+    );
+  };
+}
+
+export const reportPromptLoadIssues = createPromptLoadIssueReporter();

--- a/packages/xmcp/src/runtime/utils/resource-loader.ts
+++ b/packages/xmcp/src/runtime/utils/resource-loader.ts
@@ -1,0 +1,141 @@
+import type { ResourceFile } from "./server";
+
+const EMPTY_RESOURCE_FILE_MESSAGE = "File is empty.";
+const MISSING_DEFAULT_EXPORT_MESSAGE =
+  "File does not export a default resource handler.";
+const INVALID_DEFAULT_EXPORT_MESSAGE =
+  "Default export must be a resource handler function.";
+
+type ResourceLoadIssue = {
+  path: string;
+  message: string;
+};
+
+function createResourceLoadIssue(path: string): ResourceLoadIssue {
+  return {
+    path,
+    message: EMPTY_RESOURCE_FILE_MESSAGE,
+  };
+}
+
+function createInvalidResourceImplementationError(path: string): Error {
+  return new Error(
+    `[xmcp] Invalid resource file: ${path}\n   -> ${INVALID_DEFAULT_EXPORT_MESSAGE}`
+  );
+}
+
+function classifyResourceModule(
+  resourceModule: unknown,
+  path: string
+): "empty" | "missing-default" | "valid" {
+  if (typeof resourceModule !== "object" || resourceModule === null) {
+    throw createInvalidResourceImplementationError(path);
+  }
+
+  const moduleRecord = resourceModule as Record<string, unknown>;
+  const keys = Object.keys(moduleRecord);
+  if (keys.length === 0) {
+    return "empty";
+  }
+
+  if (!("default" in moduleRecord) || moduleRecord.default === undefined) {
+    return "missing-default";
+  }
+
+  if (typeof moduleRecord.default !== "function") {
+    throw createInvalidResourceImplementationError(path);
+  }
+
+  return "valid";
+}
+
+function toResourceFile(resourceModule: unknown): ResourceFile {
+  return resourceModule as ResourceFile;
+}
+
+export async function loadResourceModules(
+  loaders: Record<string, () => Promise<unknown>>
+) {
+  const resourceModules = new Map<string, ResourceFile>();
+  const skippedResources: ResourceLoadIssue[] = [];
+
+  const results = await Promise.all(
+    Object.entries(loaders).map(async ([path, loadResource]) => {
+      const resourceModule = await loadResource();
+      const classification = classifyResourceModule(resourceModule, path);
+
+      if (classification === "empty") {
+        return {
+          skipped: true as const,
+          issue: createResourceLoadIssue(path),
+        };
+      }
+
+      if (classification === "missing-default") {
+        return {
+          skipped: true as const,
+          issue: {
+            path,
+            message: MISSING_DEFAULT_EXPORT_MESSAGE,
+          },
+        };
+      }
+
+      return {
+        skipped: false as const,
+        path,
+        resourceModule: toResourceFile(resourceModule),
+      };
+    })
+  );
+
+  for (const result of results) {
+    if (result.skipped) {
+      skippedResources.push(result.issue);
+      continue;
+    }
+
+    resourceModules.set(result.path, result.resourceModule);
+  }
+
+  return {
+    resourceModules,
+    skippedResources,
+  };
+}
+
+function createResourceLoadIssueReporter(
+  logger: Pick<Console, "warn"> = console
+) {
+  let lastReportedSummaryKey = "";
+
+  return (skippedResources: ResourceLoadIssue[]) => {
+    const summaryKey = skippedResources
+      .map(({ path, message }) => `${path}:${message}`)
+      .sort()
+      .join("|");
+
+    if (summaryKey === lastReportedSummaryKey) {
+      return;
+    }
+
+    lastReportedSummaryKey = summaryKey;
+
+    if (skippedResources.length === 0) {
+      return;
+    }
+
+    skippedResources.forEach(({ path, message }) => {
+      logger.warn(
+        `[xmcp] Failed to load resource file: ${path}\n   -> ${message}`
+      );
+    });
+
+    const count = skippedResources.length;
+    logger.warn(
+      `[xmcp] ${count} resource${count === 1 ? "" : "s"} skipped due to empty files or missing default exports`
+    );
+  };
+}
+
+export const reportResourceLoadIssues = createResourceLoadIssueReporter();

--- a/packages/xmcp/src/runtime/utils/server.ts
+++ b/packages/xmcp/src/runtime/utils/server.ts
@@ -15,6 +15,10 @@ import {
   loadPromptModules,
   reportPromptLoadIssues,
 } from "@/runtime/utils/prompt-loader";
+import {
+  loadResourceModules,
+  reportResourceLoadIssues,
+} from "@/runtime/utils/resource-loader";
 
 export type ToolFile = {
   metadata: ToolMetadata;
@@ -93,25 +97,24 @@ export async function loadPrompts() {
   return promptModules;
 }
 
-export function loadResources() {
-  const resourceModules = new Map<string, ResourceFile>();
+export async function loadResources() {
+  const { resourceModules, skippedResources } =
+    await loadResourceModules(injectedResources);
 
-  const resourcePromises = Object.keys(injectedResources).map((path) =>
-    injectedResources[path]().then((resourceModule) => {
-      resourceModules.set(path, resourceModule);
-    })
-  );
+  reportResourceLoadIssues(skippedResources);
 
-  return [resourcePromises, resourceModules] as const;
+  return resourceModules;
 }
 
 export async function createServer() {
   const server = new McpServer(INJECTED_CONFIG);
   const [toolPromises, toolModules] = loadTools();
   const promptModulesPromise = loadPrompts();
-  const [resourcePromises, resourceModules] = loadResources();
+  const resourceModulesPromise = loadResources();
   await Promise.all(toolPromises);
-  const promptModules = await promptModulesPromise;
-  await Promise.all(resourcePromises);
+  const [promptModules, resourceModules] = await Promise.all([
+    promptModulesPromise,
+    resourceModulesPromise,
+  ]);
   return configureServer(server, toolModules, promptModules, resourceModules);
 }

--- a/packages/xmcp/src/runtime/utils/server.ts
+++ b/packages/xmcp/src/runtime/utils/server.ts
@@ -11,6 +11,10 @@ import { ZodRawShape } from "zod/v3";
 import { addResourcesToServer } from "./resources";
 import { ResourceMetadata } from "@/types/resource";
 import { uIResourceRegistry } from "./ext-apps-registry";
+import {
+  loadPromptModules,
+  reportPromptLoadIssues,
+} from "@/runtime/utils/prompt-loader";
 
 export type ToolFile = {
   metadata: ToolMetadata;
@@ -80,16 +84,13 @@ export function loadTools() {
   return [toolPromises, toolModules] as const;
 }
 
-export function loadPrompts() {
-  const promptModules = new Map<string, PromptFile>();
+export async function loadPrompts() {
+  const { promptModules, skippedPrompts } =
+    await loadPromptModules(injectedPrompts);
 
-  const promptPromises = Object.keys(injectedPrompts).map((path) =>
-    injectedPrompts[path]().then((promptModule) => {
-      promptModules.set(path, promptModule);
-    })
-  );
+  reportPromptLoadIssues(skippedPrompts);
 
-  return [promptPromises, promptModules] as const;
+  return promptModules;
 }
 
 export function loadResources() {
@@ -107,10 +108,10 @@ export function loadResources() {
 export async function createServer() {
   const server = new McpServer(INJECTED_CONFIG);
   const [toolPromises, toolModules] = loadTools();
-  const [promptPromises, promptModules] = loadPrompts();
+  const promptModulesPromise = loadPrompts();
   const [resourcePromises, resourceModules] = loadResources();
   await Promise.all(toolPromises);
-  await Promise.all(promptPromises);
+  const promptModules = await promptModulesPromise;
   await Promise.all(resourcePromises);
   return configureServer(server, toolModules, promptModules, resourceModules);
 }


### PR DESCRIPTION
Closes #529

This PR extends error handling when loading tool files (PR #528) to resource and prompt files.

- Skips empty files and missing default exports with clear, friendly warnings
- Includes the file path in error messages for invalid resource and prompt implementations
- Preserves full stack traces for real syntax/import errors
- Adds a startup summary for skipped tools
- Avoids repeated warning spam

Note: This contribution follows the same pattern as #528 to maintain code consistency, but it might be worth extracting the duplicated logic from the different loaders into a single shared utility.