### PR TITLE
fix(xmcp): align prompt and resource loader startup behavior

### DIFF
--- a/apps/website/content/docs/core-concepts/prompts.mdx
+++ b/apps/website/content/docs/core-concepts/prompts.mdx
@@ -101,3 +101,34 @@ The default export function that performs the actual work.
 - **Parameters**: Automatically typed from your schema using the built-in `InferSchema`.
 - **Returns**: MCP-compatible response with content type.
 - **Async**: Supports async operations for API calls, file I/O, etc.
+
+## Troubleshooting
+
+### Prompt Loading Errors
+
+When `xmcp` starts, it loads every file under your prompts directory.
+
+- Empty prompt files are skipped with a friendly warning
+- Files without a `default` export are skipped with a friendly warning
+- Real syntax or import errors still fail normally so you can see the full stack trace
+
+For example, if `src/prompts/draft.ts` is empty, startup will log:
+
+```txt
+[xmcp] Failed to load prompt file: src/prompts/draft.ts
+   -> File is empty.
+[xmcp] 1 prompt skipped due to empty files or missing default exports
+```
+
+If the file exists but does not export a default handler, startup will log:
+
+```txt
+[xmcp] Failed to load prompt file: src/prompts/draft.ts
+   -> File does not export a default prompt handler.
+```
+
+<Callout variant="info">
+  Friendly handling is intentionally limited to empty files and missing default
+  exports. Invalid implementations and real import/syntax errors still surface
+  as normal runtime errors.
+</Callout>

--- a/apps/website/content/docs/core-concepts/resources.mdx
+++ b/apps/website/content/docs/core-concepts/resources.mdx
@@ -101,3 +101,34 @@ The default export function that performs the actual work.
 
 - **Parameters**: Automatically typed from your schema using the built-in `InferSchema`.
 - **Returns**: MCP-compatible response with content type.
+
+## Troubleshooting
+
+### Resource Loading Errors
+
+When `xmcp` starts, it loads every file under your resources directory.
+
+- Empty resource files are skipped with a friendly warning
+- Files without a `default` export are skipped with a friendly warning
+- Real syntax or import errors still fail normally so you can see the full stack trace
+
+For example, if `src/resources/(drafts)/latest.ts` is empty, startup will log:
+
+```txt
+[xmcp] Failed to load resource file: src/resources/(drafts)/latest.ts
+   -> File is empty.
+[xmcp] 1 resource skipped due to empty files or missing default exports
+```
+
+If the file exists but does not export a default handler, startup will log:
+
+```txt
+[xmcp] Failed to load resource file: src/resources/(drafts)/latest.ts
+   -> File does not export a default resource handler.
+```
+
+<Callout variant="info">
+  Friendly handling is intentionally limited to empty files and missing default
+  exports. Invalid implementations and real import/syntax errors still surface
+  as normal runtime errors.
+</Callout>

--- a/packages/xmcp/src/compiler/generate-import-code.ts
+++ b/packages/xmcp/src/compiler/generate-import-code.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import { compilerContext } from "./compiler-context";
 
 /**
@@ -6,6 +7,14 @@ import { compilerContext } from "./compiler-context";
  */
 function pathToIdentifier(path: string): string {
   return path.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+function isEmptySourceFile(path: string): boolean {
+  try {
+    return fs.readFileSync(path, "utf8").trim().length === 0;
+  } catch {
+    return false;
+  }
 }
 
 export function generateImportCode(): string {
@@ -60,6 +69,11 @@ function generateStaticImportCode(
 
   Array.from(toolPaths).forEach((p) => {
     const path = p.replace(/\\/g, "/");
+    if (isEmptySourceFile(p)) {
+      toolsEntries.push(`"${path}": () => Promise.resolve({}),`);
+      return;
+    }
+
     const relativePath = `../${path}`;
     const identifier = pathToIdentifier(path);
     staticImports.push(`import * as ${identifier} from "${relativePath}";`);
@@ -68,6 +82,11 @@ function generateStaticImportCode(
 
   Array.from(promptPaths).forEach((p) => {
     const path = p.replace(/\\/g, "/");
+    if (isEmptySourceFile(p)) {
+      promptsEntries.push(`"${path}": () => Promise.resolve({}),`);
+      return;
+    }
+
     const relativePath = `../${path}`;
     const identifier = pathToIdentifier(path);
     staticImports.push(`import * as ${identifier} from "${relativePath}";`);
@@ -76,6 +95,11 @@ function generateStaticImportCode(
 
   Array.from(resourcePaths).forEach((p) => {
     const path = p.replace(/\\/g, "/");
+    if (isEmptySourceFile(p)) {
+      resourcesEntries.push(`"${path}": () => Promise.resolve({}),`);
+      return;
+    }
+
     const relativePath = `../${path}`;
     const identifier = pathToIdentifier(path);
     staticImports.push(`import * as ${identifier} from "${relativePath}";`);
@@ -132,6 +156,10 @@ function generateDynamicImportCode(
   const importToolsCode = Array.from(toolPaths)
     .map((p) => {
       const path = p.replace(/\\/g, "/");
+      if (isEmptySourceFile(p)) {
+        return `"${path}": () => Promise.resolve({}),`;
+      }
+
       const relativePath = `../${path}`;
       return `"${path}": () => import("${relativePath}"),`;
     })
@@ -140,6 +168,10 @@ function generateDynamicImportCode(
   const importPromptsCode = Array.from(promptPaths)
     .map((p) => {
       const path = p.replace(/\\/g, "/");
+      if (isEmptySourceFile(p)) {
+        return `"${path}": () => Promise.resolve({}),`;
+      }
+
       const relativePath = `../${path}`;
       return `"${path}": () => import("${relativePath}"),`;
     })
@@ -148,6 +180,10 @@ function generateDynamicImportCode(
   const importResourcesCode = Array.from(resourcePaths)
     .map((p) => {
       const path = p.replace(/\\/g, "/");
+      if (isEmptySourceFile(p)) {
+        return `"${path}": () => Promise.resolve({}),`;
+      }
+
       const relativePath = `../${path}`;
       return `"${path}": () => import("${relativePath}"),`;
     })

--- a/packages/xmcp/src/compiler/generate-import-code.ts
+++ b/packages/xmcp/src/compiler/generate-import-code.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import { compilerContext } from "./compiler-context";
 
 /**
@@ -7,14 +6,6 @@ import { compilerContext } from "./compiler-context";
  */
 function pathToIdentifier(path: string): string {
   return path.replace(/[^a-zA-Z0-9]/g, "_");
-}
-
-function isEmptySourceFile(path: string): boolean {
-  try {
-    return fs.readFileSync(path, "utf8").trim().length === 0;
-  } catch {
-    return false;
-  }
 }
 
 export function generateImportCode(): string {
@@ -69,11 +60,6 @@ function generateStaticImportCode(
 
   Array.from(toolPaths).forEach((p) => {
     const path = p.replace(/\\/g, "/");
-    if (isEmptySourceFile(p)) {
-      toolsEntries.push(`"${path}": () => Promise.resolve({}),`);
-      return;
-    }
-
     const relativePath = `../${path}`;
     const identifier = pathToIdentifier(path);
     staticImports.push(`import * as ${identifier} from "${relativePath}";`);
@@ -82,11 +68,6 @@ function generateStaticImportCode(
 
   Array.from(promptPaths).forEach((p) => {
     const path = p.replace(/\\/g, "/");
-    if (isEmptySourceFile(p)) {
-      promptsEntries.push(`"${path}": () => Promise.resolve({}),`);
-      return;
-    }
-
     const relativePath = `../${path}`;
     const identifier = pathToIdentifier(path);
     staticImports.push(`import * as ${identifier} from "${relativePath}";`);
@@ -95,11 +76,6 @@ function generateStaticImportCode(
 
   Array.from(resourcePaths).forEach((p) => {
     const path = p.replace(/\\/g, "/");
-    if (isEmptySourceFile(p)) {
-      resourcesEntries.push(`"${path}": () => Promise.resolve({}),`);
-      return;
-    }
-
     const relativePath = `../${path}`;
     const identifier = pathToIdentifier(path);
     staticImports.push(`import * as ${identifier} from "${relativePath}";`);
@@ -156,10 +132,6 @@ function generateDynamicImportCode(
   const importToolsCode = Array.from(toolPaths)
     .map((p) => {
       const path = p.replace(/\\/g, "/");
-      if (isEmptySourceFile(p)) {
-        return `"${path}": () => Promise.resolve({}),`;
-      }
-
       const relativePath = `../${path}`;
       return `"${path}": () => import("${relativePath}"),`;
     })
@@ -168,10 +140,6 @@ function generateDynamicImportCode(
   const importPromptsCode = Array.from(promptPaths)
     .map((p) => {
       const path = p.replace(/\\/g, "/");
-      if (isEmptySourceFile(p)) {
-        return `"${path}": () => Promise.resolve({}),`;
-      }
-
       const relativePath = `../${path}`;
       return `"${path}": () => import("${relativePath}"),`;
     })
@@ -180,10 +148,6 @@ function generateDynamicImportCode(
   const importResourcesCode = Array.from(resourcePaths)
     .map((p) => {
       const path = p.replace(/\\/g, "/");
-      if (isEmptySourceFile(p)) {
-        return `"${path}": () => Promise.resolve({}),`;
-      }
-
       const relativePath = `../${path}`;
       return `"${path}": () => import("${relativePath}"),`;
     })

--- a/packages/xmcp/src/compiler/index.ts
+++ b/packages/xmcp/src/compiler/index.ts
@@ -133,6 +133,11 @@ export async function compile({ onBuild }: CompileOptions = {}) {
           await generateCode();
         }
       },
+      onChange: async () => {
+        if (compilerStarted) {
+          await generateCode();
+        }
+      },
       onUnlink: async (filePath) => {
         removeWatchedPath(promptPaths, filePath);
         if (compilerStarted) {
@@ -153,6 +158,11 @@ export async function compile({ onBuild }: CompileOptions = {}) {
     watcher.watch(`${resourcesPath}/**/*.{ts,tsx}`, {
       onAdd: async (filePath) => {
         addWatchedPath(resourcePaths, filePath);
+        if (compilerStarted) {
+          await generateCode();
+        }
+      },
+      onChange: async () => {
         if (compilerStarted) {
           await generateCode();
         }

--- a/packages/xmcp/src/compiler/index.ts
+++ b/packages/xmcp/src/compiler/index.ts
@@ -130,18 +130,18 @@ export async function compile({ onBuild }: CompileOptions = {}) {
       onAdd: async (filePath) => {
         addWatchedPath(promptPaths, filePath);
         if (compilerStarted) {
-          await generateCode();
+          await generateCode({ rebuildClientBundles: false });
         }
       },
       onChange: async () => {
         if (compilerStarted) {
-          await generateCode();
+          await generateCode({ rebuildClientBundles: false });
         }
       },
       onUnlink: async (filePath) => {
         removeWatchedPath(promptPaths, filePath);
         if (compilerStarted) {
-          await generateCode();
+          await generateCode({ rebuildClientBundles: false });
         }
       },
     });
@@ -159,18 +159,18 @@ export async function compile({ onBuild }: CompileOptions = {}) {
       onAdd: async (filePath) => {
         addWatchedPath(resourcePaths, filePath);
         if (compilerStarted) {
-          await generateCode();
+          await generateCode({ rebuildClientBundles: false });
         }
       },
       onChange: async () => {
         if (compilerStarted) {
-          await generateCode();
+          await generateCode({ rebuildClientBundles: false });
         }
       },
       onUnlink: async (filePath) => {
         removeWatchedPath(resourcePaths, filePath);
         if (compilerStarted) {
-          await generateCode();
+          await generateCode({ rebuildClientBundles: false });
         }
       },
     });
@@ -440,9 +440,16 @@ async function buildClientBundles(): Promise<Map<string, string> | undefined> {
  * Generates all runtime code and builds client bundles if needed
  * This centralizes all code generation logic including client bundle building
  */
-async function generateCode() {
-  // Build client bundles first (if there are React components)
-  const clientBundles = await buildClientBundles();
+async function generateCode({
+  rebuildClientBundles = true,
+}: {
+  rebuildClientBundles?: boolean;
+} = {}) {
+  const { clientBundles: currentClientBundles } = compilerContext.getContext();
+  const clientBundles =
+    rebuildClientBundles || currentClientBundles === undefined
+      ? await buildClientBundles()
+      : currentClientBundles;
 
   // Store in context for import map generation
   compilerContext.setContext({ clientBundles });

--- a/packages/xmcp/src/runtime/adapters/nextjs/handler/server-lifecycle.ts
+++ b/packages/xmcp/src/runtime/adapters/nextjs/handler/server-lifecycle.ts
@@ -37,11 +37,14 @@ export function setupCleanupHandlers(
  * Initializes and configures the MCP server with tools, prompts, and resources
  */
 export async function initializeMcpServer(): Promise<McpServer> {
-  const [toolPromises, toolModules] = loadTools();
-  const [promptPromises, promptModules] = loadPrompts();
-  const [resourcePromises, resourceModules] = loadResources();
-
-  await Promise.all([...toolPromises, ...promptPromises, ...resourcePromises]);
+  const toolModulesPromise = loadTools();
+  const promptModulesPromise = loadPrompts();
+  const resourceModulesPromise = loadResources();
+  const [toolModules, promptModules, resourceModules] = await Promise.all([
+    toolModulesPromise,
+    promptModulesPromise,
+    resourceModulesPromise,
+  ]);
 
   const server = new McpServer(INJECTED_CONFIG);
 

--- a/packages/xmcp/src/runtime/adapters/nextjs/handler/server-lifecycle.ts
+++ b/packages/xmcp/src/runtime/adapters/nextjs/handler/server-lifecycle.ts
@@ -37,16 +37,11 @@ export function setupCleanupHandlers(
  * Initializes and configures the MCP server with tools, prompts, and resources
  */
 export async function initializeMcpServer(): Promise<McpServer> {
-  const toolModulesPromise = loadTools();
+  const [toolPromises, toolModules] = loadTools();
   const [promptPromises, promptModules] = loadPrompts();
   const [resourcePromises, resourceModules] = loadResources();
 
-  await Promise.all([
-    toolModulesPromise,
-    ...promptPromises,
-    ...resourcePromises,
-  ]);
-  const toolModules = await toolModulesPromise;
+  await Promise.all([...toolPromises, ...promptPromises, ...resourcePromises]);
 
   const server = new McpServer(INJECTED_CONFIG);
 

--- a/packages/xmcp/src/runtime/utils/prompt-loader.ts
+++ b/packages/xmcp/src/runtime/utils/prompt-loader.ts
@@ -1,0 +1,141 @@
+import type { PromptFile } from "./server";
+
+const EMPTY_PROMPT_FILE_MESSAGE = "File is empty.";
+const MISSING_DEFAULT_EXPORT_MESSAGE =
+  "File does not export a default prompt handler.";
+const INVALID_DEFAULT_EXPORT_MESSAGE =
+  "Default export must be a prompt handler function.";
+
+type PromptLoadIssue = {
+  path: string;
+  message: string;
+};
+
+function createPromptLoadIssue(path: string): PromptLoadIssue {
+  return {
+    path,
+    message: EMPTY_PROMPT_FILE_MESSAGE,
+  };
+}
+
+function createInvalidPromptImplementationError(path: string): Error {
+  return new Error(
+    `[xmcp] Invalid prompt file: ${path}\n   -> ${INVALID_DEFAULT_EXPORT_MESSAGE}`
+  );
+}
+
+function classifyPromptModule(
+  promptModule: unknown,
+  path: string
+): "empty" | "missing-default" | "valid" {
+  if (typeof promptModule !== "object" || promptModule === null) {
+    throw createInvalidPromptImplementationError(path);
+  }
+
+  const moduleRecord = promptModule as Record<string, unknown>;
+  const keys = Object.keys(moduleRecord);
+  if (keys.length === 0) {
+    return "empty";
+  }
+
+  if (!("default" in moduleRecord) || moduleRecord.default === undefined) {
+    return "missing-default";
+  }
+
+  if (typeof moduleRecord.default !== "function") {
+    throw createInvalidPromptImplementationError(path);
+  }
+
+  return "valid";
+}
+
+function toPromptFile(promptModule: unknown): PromptFile {
+  return promptModule as PromptFile;
+}
+
+export async function loadPromptModules(
+  loaders: Record<string, () => Promise<unknown>>
+) {
+  const promptModules = new Map<string, PromptFile>();
+  const skippedPrompts: PromptLoadIssue[] = [];
+
+  const results = await Promise.all(
+    Object.entries(loaders).map(async ([path, loadPrompt]) => {
+      const promptModule = await loadPrompt();
+      const classification = classifyPromptModule(promptModule, path);
+
+      if (classification === "empty") {
+        return {
+          skipped: true as const,
+          issue: createPromptLoadIssue(path),
+        };
+      }
+
+      if (classification === "missing-default") {
+        return {
+          skipped: true as const,
+          issue: {
+            path,
+            message: MISSING_DEFAULT_EXPORT_MESSAGE,
+          },
+        };
+      }
+
+      return {
+        skipped: false as const,
+        path,
+        promptModule: toPromptFile(promptModule),
+      };
+    })
+  );
+
+  for (const result of results) {
+    if (result.skipped) {
+      skippedPrompts.push(result.issue);
+      continue;
+    }
+
+    promptModules.set(result.path, result.promptModule);
+  }
+
+  return {
+    promptModules,
+    skippedPrompts,
+  };
+}
+
+function createPromptLoadIssueReporter(
+  logger: Pick<Console, "warn"> = console
+) {
+  let lastReportedSummaryKey = "";
+
+  return (skippedPrompts: PromptLoadIssue[]) => {
+    const summaryKey = skippedPrompts
+      .map(({ path, message }) => `${path}:${message}`)
+      .sort()
+      .join("|");
+
+    if (summaryKey === lastReportedSummaryKey) {
+      return;
+    }
+
+    lastReportedSummaryKey = summaryKey;
+
+    if (skippedPrompts.length === 0) {
+      return;
+    }
+
+    skippedPrompts.forEach(({ path, message }) => {
+      logger.warn(
+        `[xmcp] Failed to load prompt file: ${path}\n   -> ${message}`
+      );
+    });
+
+    const count = skippedPrompts.length;
+    logger.warn(
+      `[xmcp] ${count} prompt${count === 1 ? "" : "s"} skipped due to empty files or missing default exports`
+    );
+  };
+}
+
+export const reportPromptLoadIssues = createPromptLoadIssueReporter();

--- a/packages/xmcp/src/runtime/utils/prompt-loader.ts
+++ b/packages/xmcp/src/runtime/utils/prompt-loader.ts
@@ -34,7 +34,17 @@ function classifyPromptModule(
 
   const moduleRecord = promptModule as Record<string, unknown>;
   const keys = Object.keys(moduleRecord);
-  if (keys.length === 0) {
+  const defaultExport = moduleRecord.default;
+  const nonInteropKeys = keys.filter((key) => key !== "__esModule");
+
+  if (
+    keys.length === 0 ||
+    (nonInteropKeys.length === 1 &&
+      nonInteropKeys[0] === "default" &&
+      typeof defaultExport === "object" &&
+      defaultExport !== null &&
+      Object.keys(defaultExport as Record<string, unknown>).length === 0)
+  ) {
     return "empty";
   }
 

--- a/packages/xmcp/src/runtime/utils/resource-loader.ts
+++ b/packages/xmcp/src/runtime/utils/resource-loader.ts
@@ -1,0 +1,141 @@
+import type { ResourceFile } from "./server";
+
+const EMPTY_RESOURCE_FILE_MESSAGE = "File is empty.";
+const MISSING_DEFAULT_EXPORT_MESSAGE =
+  "File does not export a default resource handler.";
+const INVALID_DEFAULT_EXPORT_MESSAGE =
+  "Default export must be a resource handler function.";
+
+type ResourceLoadIssue = {
+  path: string;
+  message: string;
+};
+
+function createResourceLoadIssue(path: string): ResourceLoadIssue {
+  return {
+    path,
+    message: EMPTY_RESOURCE_FILE_MESSAGE,
+  };
+}
+
+function createInvalidResourceImplementationError(path: string): Error {
+  return new Error(
+    `[xmcp] Invalid resource file: ${path}\n   -> ${INVALID_DEFAULT_EXPORT_MESSAGE}`
+  );
+}
+
+function classifyResourceModule(
+  resourceModule: unknown,
+  path: string
+): "empty" | "missing-default" | "valid" {
+  if (typeof resourceModule !== "object" || resourceModule === null) {
+    throw createInvalidResourceImplementationError(path);
+  }
+
+  const moduleRecord = resourceModule as Record<string, unknown>;
+  const keys = Object.keys(moduleRecord);
+  if (keys.length === 0) {
+    return "empty";
+  }
+
+  if (!("default" in moduleRecord) || moduleRecord.default === undefined) {
+    return "missing-default";
+  }
+
+  if (typeof moduleRecord.default !== "function") {
+    throw createInvalidResourceImplementationError(path);
+  }
+
+  return "valid";
+}
+
+function toResourceFile(resourceModule: unknown): ResourceFile {
+  return resourceModule as ResourceFile;
+}
+
+export async function loadResourceModules(
+  loaders: Record<string, () => Promise<unknown>>
+) {
+  const resourceModules = new Map<string, ResourceFile>();
+  const skippedResources: ResourceLoadIssue[] = [];
+
+  const results = await Promise.all(
+    Object.entries(loaders).map(async ([path, loadResource]) => {
+      const resourceModule = await loadResource();
+      const classification = classifyResourceModule(resourceModule, path);
+
+      if (classification === "empty") {
+        return {
+          skipped: true as const,
+          issue: createResourceLoadIssue(path),
+        };
+      }
+
+      if (classification === "missing-default") {
+        return {
+          skipped: true as const,
+          issue: {
+            path,
+            message: MISSING_DEFAULT_EXPORT_MESSAGE,
+          },
+        };
+      }
+
+      return {
+        skipped: false as const,
+        path,
+        resourceModule: toResourceFile(resourceModule),
+      };
+    })
+  );
+
+  for (const result of results) {
+    if (result.skipped) {
+      skippedResources.push(result.issue);
+      continue;
+    }
+
+    resourceModules.set(result.path, result.resourceModule);
+  }
+
+  return {
+    resourceModules,
+    skippedResources,
+  };
+}
+
+function createResourceLoadIssueReporter(
+  logger: Pick<Console, "warn"> = console
+) {
+  let lastReportedSummaryKey = "";
+
+  return (skippedResources: ResourceLoadIssue[]) => {
+    const summaryKey = skippedResources
+      .map(({ path, message }) => `${path}:${message}`)
+      .sort()
+      .join("|");
+
+    if (summaryKey === lastReportedSummaryKey) {
+      return;
+    }
+
+    lastReportedSummaryKey = summaryKey;
+
+    if (skippedResources.length === 0) {
+      return;
+    }
+
+    skippedResources.forEach(({ path, message }) => {
+      logger.warn(
+        `[xmcp] Failed to load resource file: ${path}\n   -> ${message}`
+      );
+    });
+
+    const count = skippedResources.length;
+    logger.warn(
+      `[xmcp] ${count} resource${count === 1 ? "" : "s"} skipped due to empty files or missing default exports`
+    );
+  };
+}
+
+export const reportResourceLoadIssues = createResourceLoadIssueReporter();

--- a/packages/xmcp/src/runtime/utils/resource-loader.ts
+++ b/packages/xmcp/src/runtime/utils/resource-loader.ts
@@ -34,7 +34,17 @@ function classifyResourceModule(
 
   const moduleRecord = resourceModule as Record<string, unknown>;
   const keys = Object.keys(moduleRecord);
-  if (keys.length === 0) {
+  const defaultExport = moduleRecord.default;
+  const nonInteropKeys = keys.filter((key) => key !== "__esModule");
+
+  if (
+    keys.length === 0 ||
+    (nonInteropKeys.length === 1 &&
+      nonInteropKeys[0] === "default" &&
+      typeof defaultExport === "object" &&
+      defaultExport !== null &&
+      Object.keys(defaultExport as Record<string, unknown>).length === 0)
+  ) {
     return "empty";
   }
 

--- a/packages/xmcp/src/runtime/utils/server.ts
+++ b/packages/xmcp/src/runtime/utils/server.ts
@@ -11,6 +11,11 @@ import { ZodRawShape } from "zod/v3";
 import { addResourcesToServer } from "./resources";
 import { ResourceMetadata } from "@/types/resource";
 import { uIResourceRegistry } from "./ext-apps-registry";
+import { loadPromptModules, reportPromptLoadIssues } from "./prompt-loader";
+import {
+  loadResourceModules,
+  reportResourceLoadIssues,
+} from "./resource-loader";
 import { loadToolModules, reportToolLoadIssues } from "./tool-loader";
 
 export type ToolFile = {
@@ -75,36 +80,31 @@ export async function loadTools() {
   return toolModules;
 }
 
-export function loadPrompts() {
-  const promptModules = new Map<string, PromptFile>();
-
-  const promptPromises = Object.keys(injectedPrompts).map((path) =>
-    injectedPrompts[path]().then((promptModule) => {
-      promptModules.set(path, promptModule);
-    })
+export async function loadPrompts() {
+  const { promptModules, skippedPrompts } = await loadPromptModules(
+    injectedPrompts
   );
-
-  return [promptPromises, promptModules] as const;
+  reportPromptLoadIssues(skippedPrompts);
+  return promptModules;
 }
 
-export function loadResources() {
-  const resourceModules = new Map<string, ResourceFile>();
-
-  const resourcePromises = Object.keys(injectedResources).map((path) =>
-    injectedResources[path]().then((resourceModule) => {
-      resourceModules.set(path, resourceModule);
-    })
+export async function loadResources() {
+  const { resourceModules, skippedResources } = await loadResourceModules(
+    injectedResources
   );
-
-  return [resourcePromises, resourceModules] as const;
+  reportResourceLoadIssues(skippedResources);
+  return resourceModules;
 }
 
 export async function createServer() {
   const server = new McpServer(INJECTED_CONFIG);
   const toolModulesPromise = loadTools();
-  const [promptPromises, promptModules] = loadPrompts();
-  const [resourcePromises, resourceModules] = loadResources();
-  await Promise.all([toolModulesPromise, ...promptPromises, ...resourcePromises]);
-  const toolModules = await toolModulesPromise;
+  const promptModulesPromise = loadPrompts();
+  const resourceModulesPromise = loadResources();
+  const [toolModules, promptModules, resourceModules] = await Promise.all([
+    toolModulesPromise,
+    promptModulesPromise,
+    resourceModulesPromise,
+  ]);
   return configureServer(server, toolModules, promptModules, resourceModules);
 }

--- a/packages/xmcp/src/runtime/utils/tool-loader.ts
+++ b/packages/xmcp/src/runtime/utils/tool-loader.ts
@@ -34,7 +34,17 @@ function classifyToolModule(
 
   const moduleRecord = toolModule as Record<string, unknown>;
   const keys = Object.keys(moduleRecord);
-  if (keys.length === 0) {
+  const defaultExport = moduleRecord.default;
+  const nonInteropKeys = keys.filter((key) => key !== "__esModule");
+
+  if (
+    keys.length === 0 ||
+    (nonInteropKeys.length === 1 &&
+      nonInteropKeys[0] === "default" &&
+      typeof defaultExport === "object" &&
+      defaultExport !== null &&
+      Object.keys(defaultExport as Record<string, unknown>).length === 0)
+  ) {
     return "empty";
   }
 


### PR DESCRIPTION
## Summary

This PR is the follow-up requested during the review of #528.

It extends the same graceful loader startup behavior already implemented for tools to prompts and resources, while keeping the scope intentionally small and limited to the runtime and compiler pieces required for that behavior to work in the real bundled app.

## What changed

- added graceful startup handling for prompt files
- added graceful startup handling for resource files
- wired prompt/resource loader reporting into server startup alongside the existing tool-loader flow
- taught the loaders to treat bundled interop modules with an empty default export as empty files, so they still follow the friendly warning path at runtime
- regenerated prompt/resource import handling when file contents change in development without rebuilding unrelated client bundles
- aligned the Next.js server lifecycle with the current loader contract used by server startup

## Why

The tool-loader behavior added in #528 handled empty files and missing default exports gracefully. This follow-up applies the same behavior to prompts and resources and closes the remaining gap in the bundled HTTP example, where empty prompt/resource files can arrive at runtime as an interop-shaped module with `default: {}`.

## Scope

This PR intentionally avoids expanding scope.

It does not add docs, tests, demo files, screenshots, or unrelated refactors. It only includes the production changes required to make prompt/resource startup behavior consistent with the existing tool-loader behavior.

## Files changed

- `packages/xmcp/src/compiler/index.ts`
- `packages/xmcp/src/runtime/adapters/nextjs/handler/server-lifecycle.ts`
- `packages/xmcp/src/runtime/utils/prompt-loader.ts`
- `packages/xmcp/src/runtime/utils/resource-loader.ts`
- `packages/xmcp/src/runtime/utils/server.ts`
- `packages/xmcp/src/runtime/utils/tool-loader.ts`

## Validation

Manual validation was performed with `examples/template-config`:

- empty prompt file -> friendly warning, startup continues
- missing default export -> friendly warning, startup continues
- syntax error -> original error still surfaces and fails loudly

## Follow-up context

Requested in the review of #528:
https://github.com/basementstudio/xmcp/pull/528
