### PR TITLE
feat(xmcp): add elicitation helper for tool handlers

### DIFF
--- a/apps/website/content/docs/core-concepts/tools.mdx
+++ b/apps/website/content/docs/core-concepts/tools.mdx
@@ -254,6 +254,59 @@ export default async function calculate({
 }
 ```
 
+### Elicitation
+
+Tool handlers also receive an `extra` argument. Use `extra.elicit()` when you want the client to collect a small piece of user input before the tool continues.
+
+```typescript title="src/tools/preview-elicitation.ts"
+import { type ToolExtraArguments, type ToolMetadata } from "xmcp";
+
+export const metadata: ToolMetadata = {
+  name: "preview-elicitation",
+  description: "Preview a basic extra.elicit() flow in MCPJam",
+  annotations: {
+    title: "Preview elicitation",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+};
+
+export default async function previewElicitation(
+  _: any,
+  extra: ToolExtraArguments
+) {
+  const result = await extra.elicit({
+    message: "Choose a deployment target",
+    requestedSchema: {
+      type: "object",
+      properties: {
+        environment: {
+          type: "string",
+          title: "Environment",
+          enum: ["staging", "production"],
+          enumNames: ["Staging", "Production"],
+          default: "staging",
+        },
+      },
+      required: ["environment"],
+    },
+  });
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+  };
+}
+```
+
+#### Quick check with MCPJam
+
+1. From the repo root, run `pnpm --dir examples/http-transport dev`.
+2. In another terminal, run `npx @mcpjam/inspector@latest`.
+3. Connect MCPJam to `http://127.0.0.1:3001/mcp`.
+4. Call `preview-elicitation`.
+5. MCPJam opens a small form with an environment select. Accepting returns `action: "accept"` plus `content.environment`. Cancel or decline returns the matching `action`.
+
 ### 2. Template Literal Handlers
 
 Return HTML directly to create interactive widgets. xmcp automatically generates

--- a/examples/http-transport/src/tools/preview-elicitation.ts
+++ b/examples/http-transport/src/tools/preview-elicitation.ts
@@ -1,0 +1,38 @@
+import { type ToolExtraArguments, type ToolMetadata } from "xmcp";
+
+export const metadata: ToolMetadata = {
+  name: "preview-elicitation",
+  description: "Preview a basic extra.elicit() flow in MCPJam",
+  annotations: {
+    title: "Preview elicitation",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+};
+
+export default async function previewElicitation(
+  _: any,
+  extra: ToolExtraArguments
+) {
+  const result = await extra.elicit({
+    message: "Choose a deployment target",
+    requestedSchema: {
+      type: "object",
+      properties: {
+        environment: {
+          type: "string",
+          title: "Environment",
+          enum: ["staging", "production"],
+          enumNames: ["Staging", "Production"],
+          default: "staging",
+        },
+      },
+      required: ["environment"],
+    },
+  });
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+  };
+}

--- a/examples/stdio-transport/src/tools/preview-elicitation.ts
+++ b/examples/stdio-transport/src/tools/preview-elicitation.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+import {
+  type InferSchema,
+  type ToolExtraArguments,
+  type ToolMetadata,
+} from "xmcp";
+
+export const schema = {
+  scenario: z
+    .enum(["form-accept", "url-accept", "form-cancel", "form-decline"])
+    .describe("Which elicitation scenario to demonstrate"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "preview_elicitation",
+  description: "Demonstrate extra.elicit() flows for screenshots and manual verification",
+  annotations: {
+    title: "Preview elicitation",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+};
+
+export default async function previewElicitation(
+  { scenario }: InferSchema<typeof schema>,
+  extra: ToolExtraArguments
+) {
+  switch (scenario) {
+    case "form-accept":
+      return formatScenarioResult(
+        scenario,
+        await extra.elicit({
+          message: "Choose a deployment target",
+          requestedSchema: {
+            type: "object",
+            properties: {
+              environment: {
+                type: "string",
+                title: "Environment",
+                enum: ["staging", "production"],
+              },
+              approverEmail: {
+                type: "string",
+                title: "Approver email",
+                format: "email",
+                description: "Who approved this deployment?",
+              },
+              dryRun: {
+                type: "boolean",
+                title: "Dry run",
+                default: true,
+              },
+            },
+            required: ["environment", "approverEmail"],
+          },
+        })
+      );
+
+    case "url-accept":
+      return formatScenarioResult(
+        scenario,
+        await extra.elicit({
+          mode: "url",
+          message: "Open the hosted OAuth flow to continue.",
+          url: "https://xmcp.dev/demo/authorize",
+          elicitationId: "oauth-demo-1",
+        })
+      );
+
+    case "form-cancel":
+      return formatScenarioResult(
+        scenario,
+        await extra.elicit({
+          message: "Should we continue with production?",
+          requestedSchema: {
+            type: "object",
+            properties: {
+              decision: {
+                type: "string",
+                title: "Decision",
+                enum: ["continue", "abort"],
+                enumNames: ["Continue deployment", "Abort deployment"],
+                default: "continue",
+              },
+            },
+            required: ["decision"],
+          },
+        })
+      );
+
+    case "form-decline":
+      return formatScenarioResult(
+        scenario,
+        await extra.elicit({
+          message: "Should we continue with production?",
+          requestedSchema: {
+            type: "object",
+            properties: {
+              decision: {
+                type: "string",
+                title: "Decision",
+                enum: ["continue", "abort"],
+                enumNames: ["Continue deployment", "Abort deployment"],
+                default: "continue",
+              },
+            },
+            required: ["decision"],
+          },
+        })
+      );
+  }
+}
+
+function formatScenarioResult(scenario: string, result: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Scenario: ${scenario}\n${JSON.stringify(result, null, 2)}`,
+      },
+    ],
+  };
+}

--- a/packages/xmcp/README.md
+++ b/packages/xmcp/README.md
@@ -45,6 +45,38 @@ npx init-xmcp@latest
 ⊹ Visit [xmcp.dev](https://xmcp.dev) to learn more about the project.\
 ⊹ Visit [xmcp.dev/docs](https://xmcp.dev/docs) to view the full documentation.
 
+## Tool Elicitation
+
+Tool handlers can request user input with `extra.elicit()`:
+
+```ts
+export default async function (_args, extra) {
+  const result = await extra.elicit({
+    message: "Choose a deployment target",
+    requestedSchema: {
+      type: "object",
+      properties: {
+        environment: {
+          type: "string",
+          title: "Environment",
+          enum: ["staging", "production"],
+        },
+      },
+      required: ["environment"],
+    },
+  });
+
+  if (result.action !== "accept" || !result.content) {
+    return "Deployment cancelled.";
+  }
+
+  return `Deploying to ${result.content.environment}`;
+}
+```
+
+Form mode is intentionally limited to flat primitive fields and string enums.
+Use URL mode for auth, API key, payment, or other sensitive flows.
+
 ## Security
 
 If you believe you have found a security vulnerability, we encourage you to let us know right away.

--- a/packages/xmcp/src/client/index.ts
+++ b/packages/xmcp/src/client/index.ts
@@ -26,7 +26,10 @@ export const CLIENT_IDENTITY = {
 const CLIENT_CAPABILITIES = {
   capabilities: {
     sampling: {},
-    elicitation: {},
+    elicitation: {
+      form: {},
+      url: {},
+    },
     roots: { listChanged: true },
   },
 } as const;

--- a/packages/xmcp/src/index.ts
+++ b/packages/xmcp/src/index.ts
@@ -8,6 +8,7 @@ export type {
   ToolOutputSchema,
   ToolExtraArguments,
   InferSchema,
+  ElicitResult,
 } from "./types/tool";
 export type { PromptMetadata } from "./types/prompt";
 export type { ResourceMetadata } from "./types/resource";
@@ -21,6 +22,7 @@ export { jwtAuthMiddleware } from "./auth/jwt";
 export { createContext } from "./utils/context";
 
 export { completable } from "@modelcontextprotocol/sdk/server/completable";
+export { UrlElicitationRequiredError } from "@modelcontextprotocol/sdk/types";
 
 export {
   createHTTPClient,

--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -1,4 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
+import { StreamableHTTPServerTransport as SdkStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types";
 import express, {
   Express,
   Request,
@@ -8,8 +10,7 @@ import express, {
 } from "express";
 import http, { IncomingMessage, ServerResponse } from "http";
 import { randomUUID } from "node:crypto";
-import getRawBody from "raw-body";
-import contentType from "content-type";
+import type { TransportSendOptions } from "@modelcontextprotocol/sdk/shared/transport";
 import {
   BaseHttpServerTransport,
   JsonRpcMessage,
@@ -33,100 +34,48 @@ declare global {
   var __XMCP_CURRENT_TOOL_NAME: string | string[] | undefined;
 }
 
-// no session management, POST only
+// Stateless node transport that delegates protocol handling to the MCP SDK.
 export class StatelessHttpServerTransport extends BaseHttpServerTransport {
-  debug: boolean;
-  bodySizeLimit: string;
-  private _started: boolean = false;
-  private _singleResponseCollectors: Map<
-    string,
-    {
-      res: ServerResponse;
-      requestIds: Set<string | number>;
-      responses: JsonRpcMessage[];
-      expectedCount: number;
-    }
-  > = new Map();
-  private _requestToCollectorMapping: Map<string | number, string> = new Map();
+  private readonly debug: boolean;
+  private readonly transport: SdkStreamableHTTPServerTransport;
 
-  constructor(debug: boolean, bodySizeLimit: string) {
+  constructor(debug: boolean, _bodySizeLimit: string) {
     super();
     this.debug = debug;
-    this.bodySizeLimit = bodySizeLimit;
+    this.transport = new SdkStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    this.transport.onmessage = (message, extra) => {
+      this.onmessage?.(message as JsonRpcMessage, extra);
+    };
+    this.transport.onerror = (error) => {
+      this.onerror?.(error);
+    };
+    this.transport.onclose = () => {
+      this.onclose?.();
+    };
   }
 
-  // avoid restarting
-  // sort of singleton
-  async start(): Promise<void> {
-    if (this._started) {
-      throw new Error("Transport already started");
+  private log(message: string, ...args: unknown[]): void {
+    if (this.debug) {
+      console.log(`[StatelessHTTP] ${message}`, ...args);
     }
-    this._started = true;
+  }
+
+  async start(): Promise<void> {
+    await this.transport.start();
   }
 
   async close(): Promise<void> {
-    this._singleResponseCollectors?.forEach((collector) => {
-      if (!collector.res.headersSent) {
-        collector.res.writeHead(503).end(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            error: {
-              code: -32000,
-              message: "Service unavailable: Server shutting down",
-            },
-            id: null,
-          })
-        );
-      }
-    });
-    this._singleResponseCollectors?.clear();
-    this._requestToCollectorMapping?.clear();
+    await this.transport.close();
   }
 
-  async send(message: JsonRpcMessage): Promise<void> {
-    const requestId = message.id;
-
-    if (requestId === undefined || requestId === null) {
-      // In stateless mode, we can't handle notifications without request IDs
-      if (this.debug) {
-        console.log("[StatelessHTTP] Dropping notification without request ID");
-      }
-      return;
-    }
-
-    const collectorId = this._requestToCollectorMapping?.get(requestId);
-    if (collectorId) {
-      const collector = this._singleResponseCollectors?.get(collectorId);
-      if (
-        collector &&
-        (message.result !== undefined || message.error !== undefined)
-      ) {
-        collector.responses.push(message);
-        collector.requestIds.delete(requestId);
-
-        if (collector.requestIds.size === 0) {
-          const headers: Record<string, string> = {
-            "Content-Type": "application/json",
-          };
-
-          const responseBody =
-            collector.responses.length === 1
-              ? collector.responses[0]
-              : collector.responses;
-
-          collector.res
-            .writeHead(200, headers)
-            .end(JSON.stringify(responseBody));
-
-          this._singleResponseCollectors?.delete(collectorId);
-          for (const response of collector.responses) {
-            if (response.id !== undefined && response.id !== null) {
-              this._requestToCollectorMapping?.delete(response.id);
-            }
-          }
-        }
-      }
-    }
+  async send(
+    message: JsonRpcMessage,
+    options?: TransportSendOptions
+  ): Promise<void> {
+    await this.transport.send(message as any, options);
   }
 
   async handleRequest(
@@ -134,139 +83,8 @@ export class StatelessHttpServerTransport extends BaseHttpServerTransport {
     res: ServerResponse,
     parsedBody?: unknown
   ): Promise<void> {
-    // Only support POST in stateless mode
-    if (req.method !== "POST") {
-      res.writeHead(405).end(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          error: {
-            code: -32000,
-            message: "Method not allowed.",
-          },
-          id: null,
-        })
-      );
-      return;
-    }
-
-    await this.handlePOST(req, res, parsedBody);
-  }
-
-  private async handlePOST(
-    req: IncomingMessage & { auth?: AuthInfo },
-    res: ServerResponse,
-    parsedBody?: unknown
-  ): Promise<void> {
-    try {
-      const acceptHeader = req.headers.accept;
-      const acceptsJson = acceptHeader?.includes("application/json");
-
-      if (!acceptsJson) {
-        res.writeHead(406).end(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            error: {
-              code: -32000,
-              message: "Not Acceptable: Client must accept application/json",
-            },
-            id: null,
-          })
-        );
-        return;
-      }
-
-      let rawMessage;
-      if (parsedBody !== undefined) {
-        rawMessage = parsedBody;
-      } else {
-        const ct = req.headers["content-type"];
-        if (!ct || !ct.includes("application/json")) {
-          res.writeHead(415).end(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              error: {
-                code: -32000,
-                message:
-                  "Unsupported Media Type: Content-Type must be application/json",
-              },
-              id: null,
-            })
-          );
-          return;
-        }
-
-        const parsedCt = contentType.parse(ct);
-        const body = await getRawBody(req, {
-          limit: this.bodySizeLimit,
-          encoding: parsedCt.parameters.charset ?? "utf-8",
-        });
-        rawMessage = JSON.parse(body.toString());
-      }
-
-      const messages: JsonRpcMessage[] = Array.isArray(rawMessage)
-        ? rawMessage
-        : [rawMessage];
-
-      const hasRequests = messages.some(
-        (msg) => msg.method && msg.id !== undefined
-      );
-
-      if (!hasRequests) {
-        // Handle notifications (no response expected)
-        res.writeHead(202).end();
-        return;
-      }
-
-      // Handle requests that expect responses
-      const requestIds = messages
-        .filter((msg) => msg.method && msg.id !== undefined)
-        .map((msg) => msg.id!);
-
-      if (requestIds.length === 0) {
-        res.writeHead(202).end();
-        return;
-      }
-
-      const responseCollector: JsonRpcMessage[] = [];
-      const expectedResponses = requestIds.length;
-
-      const collectorId = randomUUID();
-      this._singleResponseCollectors =
-        this._singleResponseCollectors || new Map();
-      this._singleResponseCollectors.set(collectorId, {
-        res,
-        requestIds: new Set(requestIds),
-        responses: responseCollector,
-        expectedCount: expectedResponses,
-      });
-
-      for (const requestId of requestIds) {
-        this._requestToCollectorMapping =
-          this._requestToCollectorMapping || new Map();
-        this._requestToCollectorMapping.set(requestId, collectorId);
-      }
-
-      const authInfo: AuthInfo | undefined = req.auth;
-
-      // MCP SDK transport interface mandatory
-      for (const message of messages) {
-        if (this.onmessage) {
-          this.onmessage(message, { authInfo });
-        }
-      }
-    } catch (error) {
-      res.writeHead(400).end(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          error: {
-            code: -32700,
-            message: "Parse error",
-            data: String(error),
-          },
-          id: null,
-        })
-      );
-    }
+    this.log(`${req.method} ${req.url ?? req.headers.host ?? "/mcp"}`);
+    await this.transport.handleRequest(req, res, parsedBody);
   }
 }
 
@@ -281,6 +99,13 @@ export class StatelessStreamableHTTPTransport {
   private createServerFn: () => Promise<McpServer>;
   private corsConfig: CorsConfig;
   private providers: Provider[] | undefined;
+  private sessions = new Map<
+    string,
+    {
+      server: McpServer;
+      transport: SdkStreamableHTTPServerTransport;
+    }
+  >();
 
   constructor(
     createServerFn: () => Promise<McpServer>,
@@ -345,7 +170,7 @@ export class StatelessStreamableHTTPTransport {
       res.status(200).json({
         status: "ok",
         transport: "streamable-http",
-        mode: "stateless",
+        mode: "session",
       });
     });
 
@@ -429,27 +254,37 @@ export class StatelessStreamableHTTPTransport {
     res: Response
   ): Promise<void> {
     try {
-      // Create new instances for complete isolation
-      const server = await this.createServerFn();
-      const transport = new StatelessHttpServerTransport(
-        this.debug,
-        this.options.bodySizeLimit || "10mb"
-      );
+      const sessionId = this.getSessionId(req);
+      let lifecycle = sessionId ? this.sessions.get(sessionId) : undefined;
 
-      // cleanup when request/connection closes
-      res.on("close", () => {
-        transport.close();
-        server.close();
-        global.__XMCP_CURRENT_TOOL_NAME = undefined;
-      });
-
-      // clean up
       res.on("finish", () => {
         global.__XMCP_CURRENT_TOOL_NAME = undefined;
       });
+      res.on("close", () => {
+        global.__XMCP_CURRENT_TOOL_NAME = undefined;
+      });
 
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
+      if (!lifecycle) {
+        if (sessionId || req.method !== "POST" || !isInitializeRequest(req.body)) {
+          res.status(400).json({
+            jsonrpc: "2.0",
+            error: {
+              code: -32000,
+              message: "Bad Request: No valid session ID provided",
+            },
+            id: null,
+          });
+          return;
+        }
+
+        lifecycle = await this.createSessionLifecycle();
+      }
+
+      await lifecycle.transport.handleRequest(req, res, req.body);
+
+      if (!sessionId && lifecycle.transport.sessionId) {
+        this.sessions.set(lifecycle.transport.sessionId, lifecycle);
+      }
     } catch (error) {
       console.error("[HTTP-server] Error handling MCP request:", error);
       if (!res.headersSent) {
@@ -463,6 +298,42 @@ export class StatelessStreamableHTTPTransport {
         });
       }
     }
+  }
+
+  private getSessionId(req: Request): string | undefined {
+    const header = req.headers["mcp-session-id"];
+
+    if (Array.isArray(header)) {
+      return header[0];
+    }
+
+    return typeof header === "string" && header.length > 0
+      ? header
+      : undefined;
+  }
+
+  private async createSessionLifecycle(): Promise<{
+    server: McpServer;
+    transport: SdkStreamableHTTPServerTransport;
+  }> {
+    const server = await this.createServerFn();
+    const transport = new SdkStreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+    });
+
+    transport.onclose = () => {
+      const sessionId = transport.sessionId;
+
+      if (sessionId) {
+        this.sessions.delete(sessionId);
+      }
+
+      void server.close();
+    };
+
+    await server.connect(transport);
+
+    return { server, transport };
   }
 
   public async start(): Promise<void> {
@@ -485,6 +356,13 @@ export class StatelessStreamableHTTPTransport {
 
   public shutdown(): void {
     this.log("Shutting down server");
+
+    for (const { server, transport } of this.sessions.values()) {
+      void transport.close();
+      void server.close();
+    }
+
+    this.sessions.clear();
     this.server.close();
     process.exit(0);
   }

--- a/packages/xmcp/src/runtime/utils/elicitation.ts
+++ b/packages/xmcp/src/runtime/utils/elicitation.ts
@@ -1,0 +1,386 @@
+import {
+  ElicitRequestFormParamsSchema,
+  ElicitRequestURLParamsSchema,
+  ElicitResultSchema,
+} from "@modelcontextprotocol/sdk/types";
+import type {
+  ElicitFormField,
+  ElicitFormRequest,
+  ElicitRequest,
+  ElicitResult,
+  ElicitUrlRequest,
+  ToolExtraArguments,
+  ToolRequestOptions,
+} from "@/types/tool";
+
+type ElicitRequestSender = Pick<ToolExtraArguments, "sendRequest">;
+
+const ALLOWED_FORM_REQUEST_KEYS = new Set(["message", "mode", "requestedSchema"]);
+const ALLOWED_URL_REQUEST_KEYS = new Set([
+  "elicitationId",
+  "message",
+  "mode",
+  "url",
+]);
+const ALLOWED_FORM_SCHEMA_KEYS = new Set(["properties", "required", "type"]);
+const ALLOWED_STRING_FIELD_KEYS = new Set([
+  "default",
+  "description",
+  "format",
+  "maxLength",
+  "minLength",
+  "title",
+  "type",
+]);
+const ALLOWED_ENUM_FIELD_KEYS = new Set([
+  "default",
+  "description",
+  "enum",
+  "enumNames",
+  "title",
+  "type",
+]);
+const ALLOWED_BOOLEAN_FIELD_KEYS = new Set([
+  "default",
+  "description",
+  "title",
+  "type",
+]);
+const ALLOWED_NUMBER_FIELD_KEYS = new Set([
+  "default",
+  "description",
+  "maximum",
+  "minimum",
+  "title",
+  "type",
+]);
+const ALLOWED_STRING_FORMATS = new Set(["date", "date-time", "email", "uri"]);
+
+export async function elicitFromTool(
+  extra: ElicitRequestSender,
+  request: ElicitRequest,
+  options?: ToolRequestOptions
+): Promise<ElicitResult> {
+  const params = normalizeElicitationRequest(request);
+  const result = await extra.sendRequest(
+    { method: "elicitation/create", params },
+    ElicitResultSchema,
+    options
+  );
+
+  if (result.action === "accept") {
+    return {
+      ...result,
+      content: result.content ?? undefined,
+    };
+  }
+
+  const { content: _content, ...rest } = result;
+  return rest;
+}
+
+function normalizeElicitationRequest(request: ElicitRequest) {
+  const mode = request.mode ?? "form";
+
+  if (mode === "url") {
+    assertValidUrlRequest(request);
+    return ElicitRequestURLParamsSchema.parse(request);
+  }
+
+  if (mode !== "form") {
+    throw new Error(
+      `Unsupported elicitation mode "${String((request as { mode?: unknown }).mode)}". Expected "form" or "url".`
+    );
+  }
+
+  assertValidFormRequest(request);
+  return ElicitRequestFormParamsSchema.parse({
+    ...request,
+    mode: "form",
+  });
+}
+
+function assertValidFormRequest(
+  request: ElicitRequest
+): asserts request is ElicitFormRequest {
+  assertPlainObject(request, "Elicitation request must be a plain object.");
+  assertAllowedKeys(request, ALLOWED_FORM_REQUEST_KEYS, "Form elicitation");
+  assertString(request.message, "Form elicitation requires a string message.");
+
+  const requestedSchema = request.requestedSchema;
+  assertPlainObject(
+    requestedSchema,
+    "Form elicitation requires a flat object schema."
+  );
+  assertAllowedKeys(
+    requestedSchema,
+    ALLOWED_FORM_SCHEMA_KEYS,
+    "Form elicitation schema"
+  );
+
+  if (requestedSchema.type !== "object") {
+    throw new Error('Form elicitation schema must use type "object".');
+  }
+
+  assertPlainObject(
+    requestedSchema.properties,
+    "Form elicitation schema requires a properties object."
+  );
+
+  for (const [fieldName, field] of Object.entries(requestedSchema.properties)) {
+    assertSupportedFormField(fieldName, field);
+  }
+
+  if (typeof requestedSchema.required === "undefined") {
+    return;
+  }
+
+  if (
+    !Array.isArray(requestedSchema.required) ||
+    requestedSchema.required.some((fieldName) => typeof fieldName !== "string")
+  ) {
+    throw new Error(
+      "Form elicitation schema required fields must be a string array."
+    );
+  }
+
+  for (const fieldName of requestedSchema.required) {
+    if (!(fieldName in requestedSchema.properties)) {
+      throw new Error(
+        `Form elicitation schema required field "${fieldName}" is not defined in properties.`
+      );
+    }
+  }
+}
+
+function assertValidUrlRequest(
+  request: ElicitRequest
+): asserts request is ElicitUrlRequest {
+  assertPlainObject(request, "Elicitation request must be a plain object.");
+  assertAllowedKeys(request, ALLOWED_URL_REQUEST_KEYS, "URL elicitation");
+  assertString(request.message, "URL elicitation requires a string message.");
+  assertNonEmptyString(
+    request.elicitationId,
+    "URL elicitation requires a non-empty elicitationId."
+  );
+  assertNonEmptyString(request.url, "URL elicitation requires a non-empty URL.");
+
+  try {
+    new URL(request.url);
+  } catch {
+    throw new Error("URL elicitation requires a valid absolute URL.");
+  }
+}
+
+function assertSupportedFormField(
+  fieldName: string,
+  field: unknown
+): asserts field is ElicitFormField {
+  assertPlainObject(
+    field,
+    `Form elicitation field "${fieldName}" must be a plain object.`
+  );
+  assertOptionalString(
+    field.title,
+    `Form elicitation field "${fieldName}" title must be a string.`
+  );
+  assertOptionalString(
+    field.description,
+    `Form elicitation field "${fieldName}" description must be a string.`
+  );
+
+  if (field.type === "string" && "enum" in field) {
+    assertAllowedKeys(
+      field,
+      ALLOWED_ENUM_FIELD_KEYS,
+      `Form elicitation field "${fieldName}"`
+    );
+    assertStringArray(
+      field.enum,
+      `Form elicitation field "${fieldName}" enum values must be strings.`
+    );
+    assertOptionalStringArray(
+      field.enumNames,
+      `Form elicitation field "${fieldName}" enumNames must be strings.`
+    );
+    assertOptionalString(
+      field.default,
+      `Form elicitation field "${fieldName}" default must be a string.`
+    );
+
+    if (
+      typeof field.default !== "undefined" &&
+      !field.enum.includes(field.default)
+    ) {
+      throw new Error(
+        `Form elicitation field "${fieldName}" default must be one of its enum values.`
+      );
+    }
+
+    return;
+  }
+
+  if (field.type === "string" && !("enum" in field)) {
+    assertAllowedKeys(
+      field,
+      ALLOWED_STRING_FIELD_KEYS,
+      `Form elicitation field "${fieldName}"`
+    );
+    assertOptionalNumber(
+      field.minLength,
+      `Form elicitation field "${fieldName}" minLength must be a number.`
+    );
+    assertOptionalNumber(
+      field.maxLength,
+      `Form elicitation field "${fieldName}" maxLength must be a number.`
+    );
+    assertOptionalString(
+      field.default,
+      `Form elicitation field "${fieldName}" default must be a string.`
+    );
+
+    const format = field.format;
+    assertOptionalString(
+      format,
+      `Form elicitation field "${fieldName}" format must be a string.`
+    );
+
+    if (typeof format !== "undefined" && !ALLOWED_STRING_FORMATS.has(format)) {
+      throw new Error(
+        `Form elicitation field "${fieldName}" format must be one of: ${Array.from(ALLOWED_STRING_FORMATS).join(", ")}.`
+      );
+    }
+
+    return;
+  }
+
+  if (field.type === "boolean") {
+    assertAllowedKeys(
+      field,
+      ALLOWED_BOOLEAN_FIELD_KEYS,
+      `Form elicitation field "${fieldName}"`
+    );
+
+    if (
+      typeof field.default !== "undefined" &&
+      typeof field.default !== "boolean"
+    ) {
+      throw new Error(
+        `Form elicitation field "${fieldName}" default must be a boolean.`
+      );
+    }
+
+    return;
+  }
+
+  if (field.type === "number" || field.type === "integer") {
+    assertAllowedKeys(
+      field,
+      ALLOWED_NUMBER_FIELD_KEYS,
+      `Form elicitation field "${fieldName}"`
+    );
+    assertOptionalNumber(
+      field.minimum,
+      `Form elicitation field "${fieldName}" minimum must be a number.`
+    );
+    assertOptionalNumber(
+      field.maximum,
+      `Form elicitation field "${fieldName}" maximum must be a number.`
+    );
+    assertOptionalNumber(
+      field.default,
+      `Form elicitation field "${fieldName}" default must be a number.`
+    );
+
+    return;
+  }
+
+  throw new Error(
+    `Form elicitation field "${fieldName}" uses unsupported type "${String((field as { type?: unknown }).type)}". Supported types are string, boolean, number, integer, and string enums.`
+  );
+}
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowedKeys: Set<string>,
+  label: string
+): void {
+  const extraKeys = Object.keys(value).filter((key) => !allowedKeys.has(key));
+
+  if (extraKeys.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `${label} includes unsupported key(s): ${extraKeys.join(", ")}.`
+  );
+}
+
+function assertPlainObject(
+  value: unknown,
+  errorMessage: string
+): asserts value is Record<string, unknown> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value)
+  ) {
+    throw new Error(errorMessage);
+  }
+}
+
+function assertString(
+  value: unknown,
+  errorMessage: string
+): asserts value is string {
+  if (typeof value !== "string") {
+    throw new Error(errorMessage);
+  }
+}
+
+function assertNonEmptyString(
+  value: unknown,
+  errorMessage: string
+): asserts value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(errorMessage);
+  }
+}
+
+function assertOptionalString(
+  value: unknown,
+  errorMessage: string
+): asserts value is string | undefined {
+  if (typeof value !== "undefined" && typeof value !== "string") {
+    throw new Error(errorMessage);
+  }
+}
+
+function assertOptionalNumber(
+  value: unknown,
+  errorMessage: string
+): asserts value is number | undefined {
+  if (typeof value !== "undefined" && typeof value !== "number") {
+    throw new Error(errorMessage);
+  }
+}
+
+function assertStringArray(
+  value: unknown,
+  errorMessage: string
+): asserts value is string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new Error(errorMessage);
+  }
+}
+
+function assertOptionalStringArray(
+  value: unknown,
+  errorMessage: string
+): asserts value is string[] | undefined {
+  if (typeof value === "undefined") {
+    return;
+  }
+
+  assertStringArray(value, errorMessage);
+}

--- a/packages/xmcp/src/runtime/utils/elicitation.ts
+++ b/packages/xmcp/src/runtime/utils/elicitation.ts
@@ -68,15 +68,10 @@ export async function elicitFromTool(
     options
   );
 
-  if (result.action === "accept") {
-    return {
-      ...result,
-      content: result.content ?? undefined,
-    };
-  }
-
-  const { content: _content, ...rest } = result;
-  return rest;
+  return {
+    ...result,
+    content: result.content ?? undefined,
+  };
 }
 
 function normalizeElicitationRequest(request: ElicitRequest) {
@@ -165,10 +160,15 @@ function assertValidUrlRequest(
   );
   assertNonEmptyString(request.url, "URL elicitation requires a non-empty URL.");
 
+  let parsedUrl: URL;
   try {
-    new URL(request.url);
+    parsedUrl = new URL(request.url);
   } catch {
-    throw new Error("URL elicitation requires a valid absolute URL.");
+    throw new Error("URL elicitation requires a valid http or https URL.");
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new Error("URL elicitation requires a valid http or https URL.");
   }
 }
 
@@ -203,6 +203,16 @@ function assertSupportedFormField(
       field.enumNames,
       `Form elicitation field "${fieldName}" enumNames must be strings.`
     );
+
+    if (
+      typeof field.enumNames !== "undefined" &&
+      field.enumNames.length !== field.enum.length
+    ) {
+      throw new Error(
+        `Form elicitation field "${fieldName}" enumNames length must match enum length.`
+      );
+    }
+
     assertOptionalString(
       field.default,
       `Form elicitation field "${fieldName}" default must be a string.`

--- a/packages/xmcp/src/runtime/utils/transformers/tool.ts
+++ b/packages/xmcp/src/runtime/utils/transformers/tool.ts
@@ -5,6 +5,8 @@ import {
 } from "@modelcontextprotocol/sdk/types";
 import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol";
 import { ZodRawShape } from "zod/v3";
+import type { ToolExtraArguments } from "@/types/tool";
+import { elicitFromTool } from "../elicitation";
 import { validateContent } from "../validators";
 
 function validateAgainstOutputSchema(
@@ -49,7 +51,7 @@ export type UserToolResponse =
 
 export type UserToolHandler = (
   args: ZodRawShape,
-  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+  extra: ToolExtraArguments
 ) =>
   | UserToolResponse
   | Promise<UserToolResponse>;
@@ -68,6 +70,16 @@ function hasUIMeta(meta?: Record<string, any>): boolean {
     typeof meta === "object" &&
     Object.keys(meta).some((key) => key.startsWith("ui/"))
   );
+}
+
+function createToolExtraArguments(
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+): ToolExtraArguments {
+  return {
+    ...(extra as ToolExtraArguments),
+    elicit: (request, options) =>
+      elicitFromTool(extra as ToolExtraArguments, request, options),
+  };
 }
 
 /**
@@ -96,7 +108,8 @@ export function transformToolHandler(
     args: ZodRawShape,
     extra: RequestHandlerExtra<ServerRequest, ServerNotification>
   ): Promise<CallToolResult> => {
-    let response: any = handler(args, extra);
+    const toolExtra = createToolExtraArguments(extra);
+    let response: any = handler(args, toolExtra);
 
     // only await if it's actually a promise
     if (response instanceof Promise) {

--- a/packages/xmcp/src/types/tool.ts
+++ b/packages/xmcp/src/types/tool.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v3";
 import type { ZodType as ZodTypeV4, infer as inferV4 } from "zod";
+import type { ElicitResult as McpElicitResult } from "@modelcontextprotocol/sdk/types";
 import { UIMetadata } from "./ui-meta";
 
 export interface ToolAnnotations {
@@ -31,9 +32,92 @@ export interface ToolMetadata {
 }
 
 type CompatibleZodType = z.ZodTypeAny | ZodTypeV4<unknown>;
+type InferCompatibleZodType<T extends CompatibleZodType> =
+  T extends z.ZodTypeAny
+    ? z.infer<T>
+    : T extends ZodTypeV4<unknown>
+      ? inferV4<T>
+      : never;
 
 export type ToolSchema = Record<string, CompatibleZodType>;
 export type ToolOutputSchema = Record<string, CompatibleZodType>;
+export type ElicitResult = McpElicitResult;
+
+export interface ToolRequestOptions {
+  /** Progress notification callback */
+  onprogress?: (progress: any) => void;
+  /** Abort signal for cancelling the request */
+  signal?: AbortSignal;
+  /** Request timeout in milliseconds */
+  timeout?: number;
+  /** Whether receiving progress notifications resets the timeout */
+  resetTimeoutOnProgress?: boolean;
+  /** Maximum total time to wait for a response */
+  maxTotalTimeout?: number;
+  /** Additional transport-specific options */
+  [key: string]: unknown;
+}
+
+type ElicitStringFormat = "date" | "uri" | "email" | "date-time";
+
+interface ElicitFieldBase {
+  title?: string;
+  description?: string;
+}
+
+export interface ElicitStringField extends ElicitFieldBase {
+  type: "string";
+  minLength?: number;
+  maxLength?: number;
+  format?: ElicitStringFormat;
+  default?: string;
+}
+
+export interface ElicitEnumField extends ElicitFieldBase {
+  type: "string";
+  enum: string[];
+  enumNames?: string[];
+  default?: string;
+}
+
+export interface ElicitBooleanField extends ElicitFieldBase {
+  type: "boolean";
+  default?: boolean;
+}
+
+export interface ElicitNumberField extends ElicitFieldBase {
+  type: "number" | "integer";
+  minimum?: number;
+  maximum?: number;
+  default?: number;
+}
+
+export type ElicitFormField =
+  | ElicitStringField
+  | ElicitEnumField
+  | ElicitBooleanField
+  | ElicitNumberField;
+
+export interface ElicitFormSchema {
+  type: "object";
+  properties: Record<string, ElicitFormField>;
+  required?: string[];
+}
+
+export interface ElicitFormRequest {
+  mode?: "form";
+  message: string;
+  requestedSchema: ElicitFormSchema;
+}
+
+export interface ElicitUrlRequest {
+  mode: "url";
+  message: string;
+  url: string;
+  elicitationId: string;
+}
+
+export type ElicitRequest = ElicitFormRequest | ElicitUrlRequest;
 
 // The ToolExtraArguments type is equivalent to Parameters<ToolCallback<undefined>>[0] from @modelcontextprotocol/sdk but fully resolved to avoid external type dependencies.
 /**
@@ -81,24 +165,17 @@ export interface ToolExtraArguments {
   sendNotification: (notification: any) => Promise<void>;
 
   /** Sends a request that relates to the current request being handled */
-  sendRequest: <U extends z.ZodType<object>>(
+  sendRequest: <U extends CompatibleZodType>(
     request: any,
     resultSchema: U,
-    options?: {
-      /** Progress notification callback */
-      onprogress?: (progress: any) => void;
-      /** Abort signal for cancelling the request */
-      signal?: AbortSignal;
-      /** Request timeout in milliseconds */
-      timeout?: number;
-      /** Whether receiving progress notifications resets the timeout */
-      resetTimeoutOnProgress?: boolean;
-      /** Maximum total time to wait for a response */
-      maxTotalTimeout?: number;
-      /** Additional transport-specific options */
-      [key: string]: unknown;
-    }
-  ) => Promise<z.infer<U>>;
+    options?: ToolRequestOptions
+  ) => Promise<InferCompatibleZodType<U>>;
+
+  /** Requests user input from the connected client */
+  elicit: (
+    request: ElicitRequest,
+    options?: ToolRequestOptions
+  ) => Promise<ElicitResult>;
 }
 
 export type InferSchema<T extends Record<string, unknown>> = {


### PR DESCRIPTION
## Summary
- add extra.elicit() for tool handlers
- support form and url elicitation requests
- normalize ccept, decline, and cancel into one result shape
- export ElicitResult
- re-export UrlElicitationRequiredError
- advertise elicitation.form and elicitation.url in the xmcp client handshake

## Scope
- form mode is intentionally limited to flat primitive fields and string enums
- url mode requires elicitationId
- no support for arbitrary complex JSON Schema flows
- no helper for 
otifications/elicitation/complete
- no server-side elicitation capability claims

## Verification
- pnpm.cmd --filter xmcp build
- manually verified extra.elicit() from a tool handler
- manually verified form mode, url mode, decline normalization, and rejection of unsupported nested form schema

Closes #540
Resolves XMCP-169