### PR TITLE
xmcp/headers and nextjs bug fix

### DIFF
--- a/packages/xmcp/package.json
+++ b/packages/xmcp/package.json
@@ -43,6 +43,11 @@
       "require": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./headers": {
+      "types": "./dist/runtime/headers.d.ts",
+      "require": "./dist/runtime/headers.js",
+      "default": "./dist/runtime/headers.js"
+    },
     "./cloudflare": {
       "types": "./dist/cloudflare.d.ts",
       "require": "./dist/cloudflare.js",
@@ -52,6 +57,9 @@
   },
   "typesVersions": {
     "*": {
+      "headers": [
+        "dist/runtime/headers.d.ts"
+      ],
       "cloudflare": [
         "dist/cloudflare.d.ts"
       ]

--- a/packages/xmcp/src/runtime/adapters/nextjs/handler/node-to-web-adapter.ts
+++ b/packages/xmcp/src/runtime/adapters/nextjs/handler/node-to-web-adapter.ts
@@ -18,9 +18,19 @@ export function nodeToWebAdapter(
     const emitter = new EventEmitter();
     let statusCode = 200;
     let headers: OutgoingHttpHeaders | undefined;
-    let body = "";
+    const bodyChunks: Uint8Array[] = [];
     let headersWritten = false;
     let resolved = false;
+    let destroyed = false;
+
+    const appendBodyChunk = (chunk: Buffer | Uint8Array | string) => {
+      if (typeof chunk === "string") {
+        bodyChunks.push(Buffer.from(chunk));
+        return;
+      }
+
+      bodyChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    };
 
     // Setup abort signal handling
     signal.addEventListener("abort", () => {
@@ -44,20 +54,20 @@ export function nodeToWebAdapter(
         return mockResponse;
       },
 
-      write(chunk: Buffer | string): boolean {
+      write(chunk: Buffer | Uint8Array | string): boolean {
         if (!resolved) {
-          body += chunk.toString();
+          appendBodyChunk(chunk);
         }
         return true;
       },
 
-      end(data?: Buffer | string) {
+      end(data?: Buffer | Uint8Array | string) {
         if (resolved) {
           return mockResponse;
         }
 
         if (data) {
-          body += data.toString();
+          appendBodyChunk(data);
         }
 
         // Ensure headers were written (default to 200 if not)
@@ -70,7 +80,7 @@ export function nodeToWebAdapter(
 
         // Create Web Response
         resolve(
-          new Response(body, {
+          new Response(Buffer.concat(bodyChunks), {
             status: statusCode,
             headers: headers as Record<string, string>,
           })
@@ -85,6 +95,22 @@ export function nodeToWebAdapter(
         return mockResponse;
       },
 
+      off(event: string, listener: (...args: unknown[]) => void) {
+        emitter.off(event, listener);
+        return mockResponse;
+      },
+
+      removeListener(event: string, listener: (...args: unknown[]) => void) {
+        emitter.removeListener(event, listener);
+        return mockResponse;
+      },
+
+      destroy(_error?: Error) {
+        destroyed = true;
+        emitter.emit("close");
+        return mockResponse;
+      },
+
       get statusCode(): number {
         return statusCode;
       },
@@ -95,6 +121,14 @@ export function nodeToWebAdapter(
 
       get headersSent(): boolean {
         return headersWritten;
+      },
+
+      get destroyed(): boolean {
+        return destroyed;
+      },
+
+      get writable(): boolean {
+        return !destroyed;
       },
     } as ServerResponse;
 

--- a/packages/xmcp/src/runtime/adapters/nextjs/handler/request-converter.ts
+++ b/packages/xmcp/src/runtime/adapters/nextjs/handler/request-converter.ts
@@ -10,6 +10,25 @@ export interface RequestConversionOptions {
   auth?: AuthInfo;
 }
 
+function toRawHeaders(headers: IncomingHttpHeaders): string[] {
+  const rawHeaders: string[] = [];
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        rawHeaders.push(key, item);
+      }
+      continue;
+    }
+
+    rawHeaders.push(key, value);
+  }
+
+  return rawHeaders;
+}
+
 /**
  * Creates a Node.js IncomingMessage from Web Request options.
  * This adapter enables the MCP SDK to work with Web Request objects.
@@ -37,6 +56,7 @@ export function createIncomingMessage(
   req.method = method;
   req.url = url;
   req.headers = headers;
+  req.rawHeaders = toRawHeaders(headers);
 
   // Set auth if available (can be set by middleware)
   if (auth) {

--- a/packages/xmcp/src/runtime/adapters/nextjs/index.ts
+++ b/packages/xmcp/src/runtime/adapters/nextjs/index.ts
@@ -10,6 +10,8 @@ import {
 } from "./handler/server-lifecycle";
 import { createIncomingMessage } from "./handler/request-converter";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types";
+import { httpRequestContextProvider } from "@/runtime/contexts/http-request-context";
+import { randomUUID } from "node:crypto";
 
 const BODY_SIZE_LIMIT = "10mb";
 
@@ -23,35 +25,40 @@ export async function xmcpHandler(request: Request): Promise<Response> {
     return createMethodNotAllowedResponse();
   }
 
-  return nodeToWebAdapter(request.signal, async (res: ServerResponse) => {
-    try {
-      // Initialize server and transport
-      const lifecycle = await createServerLifecycle(BODY_SIZE_LIMIT);
+  const id = randomUUID();
+  const requestHeaders = Object.fromEntries(request.headers.entries());
 
-      // Setup cleanup handlers
-      setupCleanupHandlers(res, lifecycle);
+  return httpRequestContextProvider({ id, headers: requestHeaders }, () => {
+    return nodeToWebAdapter(request.signal, async (res: ServerResponse) => {
+      try {
+        // Initialize server and transport
+        const lifecycle = await createServerLifecycle(BODY_SIZE_LIMIT);
 
-      // Parse request body
-      const bodyContent = await request.json();
+        // Setup cleanup handlers
+        setupCleanupHandlers(res, lifecycle);
 
-      // Convert Web Request to Node.js IncomingMessage
-      const incomingRequest = createIncomingMessage({
-        method: request.method,
-        url: request.url,
-        headers: Object.fromEntries(request.headers.entries()),
-        auth: request.auth,
-      });
+        // Parse request body
+        const bodyContent = await request.json();
 
-      // Handle request through transport
-      await lifecycle.transport.handleRequest(
-        incomingRequest,
-        res,
-        bodyContent
-      );
-    } catch (error) {
-      console.error("[Next.js MCP] Error handling MCP request:", error);
-      sendInternalServerError(res);
-    }
+        // Convert Web Request to Node.js IncomingMessage
+        const incomingRequest = createIncomingMessage({
+          method: request.method,
+          url: request.url,
+          headers: requestHeaders,
+          auth: request.auth,
+        });
+
+        // Handle request through transport
+        await lifecycle.transport.handleRequest(
+          incomingRequest,
+          res,
+          bodyContent
+        );
+      } catch (error) {
+        console.error("[Next.js MCP] Error handling MCP request:", error);
+        sendInternalServerError(res);
+      }
+    });
   });
 }
 

--- a/packages/xmcp/src/runtime/headers.ts
+++ b/packages/xmcp/src/runtime/headers.ts
@@ -1,7 +1,42 @@
 import { getHttpRequestContext } from "./contexts/http-request-context";
 
 export const headers = () => {
-  const headers = getHttpRequestContext().headers;
+  const currentHeaders = getHttpRequestContext().headers;
+  const headerLookup = new Map<string, string>();
 
-  return headers;
+  for (const key of Object.keys(currentHeaders)) {
+    const normalizedKey = key.toLowerCase();
+
+    if (!headerLookup.has(normalizedKey)) {
+      headerLookup.set(normalizedKey, key);
+    }
+  }
+
+  const resolveHeaderKey = (prop: string): string => {
+    return headerLookup.get(prop.toLowerCase()) ?? prop;
+  };
+
+  return new Proxy(currentHeaders, {
+    get(target, prop, receiver) {
+      if (typeof prop !== "string") {
+        return Reflect.get(target, prop, receiver);
+      }
+
+      return Reflect.get(target, resolveHeaderKey(prop), receiver);
+    },
+    has(target, prop) {
+      if (typeof prop !== "string") {
+        return Reflect.has(target, prop);
+      }
+
+      return Reflect.has(target, resolveHeaderKey(prop));
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      if (typeof prop !== "string") {
+        return Reflect.getOwnPropertyDescriptor(target, prop);
+      }
+
+      return Reflect.getOwnPropertyDescriptor(target, resolveHeaderKey(prop));
+    },
+  });
 };

--- a/packages/xmcp/src/utils/context.ts
+++ b/packages/xmcp/src/utils/context.ts
@@ -8,7 +8,7 @@ type SetContext<T extends DefaultContext> = (data: Partial<T>) => void;
 
 export interface Context<T extends DefaultContext> {
   /** Run a callback with a specific context. */
-  provider: (initialValue: T, callback: () => void) => void;
+  provider: <R>(initialValue: T, callback: () => R) => R;
   /** Get the context. */
   getContext: GetContext<T>;
   /** Partially update the context. */
@@ -88,7 +88,7 @@ export function createContext<T extends Object>({
     Object.assign(store, data);
   };
 
-  const provider = (initialValue: T, callback: () => void) => {
+  const provider = <R>(initialValue: T, callback: () => R): R => {
     fallbackStoreWrapper.current = initialValue;
     return context.run(initialValue, callback);
   };


### PR DESCRIPTION
## Description
xmcp/headers would “sometimes not detect Authorization headers,” using code that read headerlist["Authorization"] inside a tool.

## What was found
- In the Next.js adapter, the request was never wrapped in the per-request async context that xmcp/headers reads from. That meant headers() could miss request headers entirely during tool execution.
- Even when headers were present, our runtime normalized them to lowercase, so user code like headers()["Authorization"] failed because the stored key was typically authorization.
- While reproducing the issue end-to-end, we found two more Next.js transport problems that affected real MCP clients:
- the synthetic IncomingMessage did not populate rawHeaders, which the MCP SDK’s Node bridge uses to read headers like Accept
- the Node-to-Web response bridge was serializing streamed Uint8Array chunks with .toString(), turning SSE responses into comma-separated byte values instead of valid text/event- stream