### PR TITLE
Expose initialize clientInfo in tool handler extra context

### DIFF
--- a/apps/website/content/docs/adapters/nestjs.mdx
+++ b/apps/website/content/docs/adapters/nestjs.mdx
@@ -365,6 +365,7 @@ export default async function whoami(
   extra: ToolExtraArguments
 ) {
   const authInfo = extra.authInfo;
+  const clientInfo = extra.clientInfo;
 
   if (!authInfo) {
     return "Not authenticated";
@@ -374,6 +375,8 @@ export default async function whoami(
     {
       clientId: authInfo.clientId,
       scopes: authInfo.scopes,
+      clientName: clientInfo?.name,
+      clientVersion: clientInfo?.version,
     },
     null,
     2

--- a/apps/website/content/docs/core-concepts/tools.mdx
+++ b/apps/website/content/docs/core-concepts/tools.mdx
@@ -254,6 +254,8 @@ export default async function calculate({
 
 Tool handlers also receive an `extra` argument. Use `extra.elicit()` when you want the client to collect a small piece of user input before the tool continues.
 
+When your server is called over HTTP and the client sends an MCP `initialize` request, `extra.clientInfo` is available with protocol-level client identity (`name`, `version`, and optional fields like `title`).
+
 ```typescript title="src/tools/preview-elicitation.ts"
 import { type ToolExtraArguments, type ToolMetadata } from "xmcp";
 

--- a/examples/http-transport/src/tools/extra-arguments.ts
+++ b/examples/http-transport/src/tools/extra-arguments.ts
@@ -17,7 +17,7 @@ export default async function extraArguments(
   _: any,
   extra: ToolExtraArguments
 ) {
-  const extraArguments = JSON.stringify(extra); // to render a readable string
+  const extraArguments = JSON.stringify(extra, null, 2); // to render a readable string
 
   return `Your extra arguments are: ${extraArguments}`;
 }

--- a/examples/template-config/src/tools/extra-arguments.ts
+++ b/examples/template-config/src/tools/extra-arguments.ts
@@ -17,7 +17,7 @@ export default async function extraArguments(
   _: unknown,
   extra: ToolExtraArguments
 ) {
-  const extraArguments = JSON.stringify(extra); // to render a readable string
+  const extraArguments = JSON.stringify(extra, null, 2); // to render a readable string
 
   return `Your extra arguments are: ${extraArguments}`;
 }

--- a/packages/xmcp/src/index.ts
+++ b/packages/xmcp/src/index.ts
@@ -1,5 +1,9 @@
 import dotenv from "dotenv";
-export type { Middleware, WebMiddleware, WebMiddlewareContext } from "./types/middleware";
+export type {
+  Middleware,
+  WebMiddleware,
+  WebMiddlewareContext,
+} from "./types/middleware";
 dotenv.config();
 
 export type {
@@ -10,6 +14,7 @@ export type {
   InferSchema,
   ElicitResult,
 } from "./types/tool";
+export type { McpClientInfo } from "./types/client-info";
 export type { PromptMetadata } from "./types/prompt";
 export type { ResourceMetadata } from "./types/resource";
 export type { UIMetadata } from "./types/ui-meta";

--- a/packages/xmcp/src/runtime/adapters/express/index.ts
+++ b/packages/xmcp/src/runtime/adapters/express/index.ts
@@ -4,6 +4,7 @@ import { StatelessHttpServerTransport } from "@/runtime/transports/http/stateles
 import { setHeaders } from "@/runtime/transports/http/cors";
 import { httpRequestContextProvider } from "@/runtime/contexts/http-request-context";
 import { randomUUID } from "node:crypto";
+import { extractClientInfoFromMessages } from "@/runtime/utils/client-info";
 
 // cors config
 const corsOrigin = HTTP_CORS_ORIGIN as string;
@@ -19,51 +20,56 @@ const bodySizeLimit = HTTP_BODY_SIZE_LIMIT as string;
 export async function xmcpHandler(req: Request, res: Response) {
   return new Promise((resolve) => {
     const id = randomUUID();
-    httpRequestContextProvider({ id, headers: req.headers }, async () => {
-      try {
-        setHeaders(
-          res,
-          {
-            origin: corsOrigin,
-            methods: corsMethods,
-            allowedHeaders: corsAllowedHeaders,
-            exposedHeaders: corsExposedHeaders,
-            credentials: corsCredentials,
-            maxAge: corsMaxAge,
-          },
-          req.headers.origin
-        );
+    const clientInfo = extractClientInfoFromMessages(req.body);
 
-        const server = await createServer();
-        const transport = new StatelessHttpServerTransport(
-          debug,
-          bodySizeLimit || "10mb"
-        );
-
-        // cleanup when request/connection closes
-        res.on("close", () => {
-          transport.close();
-          server.close();
-        });
-
-        await server.connect(transport);
-
-        await transport.handleRequest(req, res, req.body).then(() => {
-          resolve(res);
-        });
-      } catch (error) {
-        console.error("[HTTP-server] Error handling MCP request:", error);
-        if (!res.headersSent) {
-          res.status(500).json({
-            jsonrpc: "2.0",
-            error: {
-              code: -32603,
-              message: "Internal server error",
+    httpRequestContextProvider(
+      { id, headers: req.headers, clientInfo },
+      async () => {
+        try {
+          setHeaders(
+            res,
+            {
+              origin: corsOrigin,
+              methods: corsMethods,
+              allowedHeaders: corsAllowedHeaders,
+              exposedHeaders: corsExposedHeaders,
+              credentials: corsCredentials,
+              maxAge: corsMaxAge,
             },
-            id: null,
+            req.headers.origin
+          );
+
+          const server = await createServer();
+          const transport = new StatelessHttpServerTransport(
+            debug,
+            bodySizeLimit || "10mb"
+          );
+
+          // cleanup when request/connection closes
+          res.on("close", () => {
+            transport.close();
+            server.close();
           });
+
+          await server.connect(transport);
+
+          await transport.handleRequest(req, res, req.body).then(() => {
+            resolve(res);
+          });
+        } catch (error) {
+          console.error("[HTTP-server] Error handling MCP request:", error);
+          if (!res.headersSent) {
+            res.status(500).json({
+              jsonrpc: "2.0",
+              error: {
+                code: -32603,
+                message: "Internal server error",
+              },
+              id: null,
+            });
+          }
         }
       }
-    });
+    );
   });
 }

--- a/packages/xmcp/src/runtime/adapters/nestjs/xmcp.service.ts
+++ b/packages/xmcp/src/runtime/adapters/nestjs/xmcp.service.ts
@@ -11,6 +11,7 @@ import { setHeaders } from "@/runtime/transports/http/cors";
 import { httpRequestContextProvider } from "@/runtime/contexts/http-request-context";
 import { randomUUID } from "node:crypto";
 import type { CorsConfig } from "@/compiler/config";
+import { extractClientInfoFromMessages } from "@/runtime/utils/client-info";
 
 const corsConfig = HTTP_CORS_CONFIG as CorsConfig;
 
@@ -41,8 +42,10 @@ export class XmcpService implements OnModuleInit, OnModuleDestroy {
     this.logger.debug(`Request ${requestId} started`);
 
     return new Promise((resolve) => {
+      const clientInfo = extractClientInfoFromMessages(req.body);
+
       httpRequestContextProvider(
-        { id: requestId, headers: req.headers },
+        { id: requestId, headers: req.headers, clientInfo },
         async () => {
           try {
             setHeaders(res, corsConfig, req.headers.origin);

--- a/packages/xmcp/src/runtime/adapters/nextjs/index.ts
+++ b/packages/xmcp/src/runtime/adapters/nextjs/index.ts
@@ -12,6 +12,10 @@ import { createIncomingMessage } from "./handler/request-converter";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types";
 import { httpRequestContextProvider } from "@/runtime/contexts/http-request-context";
 import { randomUUID } from "node:crypto";
+import {
+  setHttpRequestContext,
+} from "@/runtime/contexts/http-request-context";
+import { extractClientInfoFromMessages } from "@/runtime/utils/client-info";
 
 const BODY_SIZE_LIMIT = "10mb";
 
@@ -28,7 +32,9 @@ export async function xmcpHandler(request: Request): Promise<Response> {
   const id = randomUUID();
   const requestHeaders = Object.fromEntries(request.headers.entries());
 
-  return httpRequestContextProvider({ id, headers: requestHeaders }, () => {
+  return httpRequestContextProvider(
+    { id, headers: requestHeaders, clientInfo: undefined },
+    () => {
     return nodeToWebAdapter(request.signal, async (res: ServerResponse) => {
       try {
         // Initialize server and transport
@@ -39,6 +45,8 @@ export async function xmcpHandler(request: Request): Promise<Response> {
 
         // Parse request body
         const bodyContent = await request.json();
+        const clientInfo = extractClientInfoFromMessages(bodyContent);
+        setHttpRequestContext({ clientInfo });
 
         // Convert Web Request to Node.js IncomingMessage
         const incomingRequest = createIncomingMessage({
@@ -59,7 +67,8 @@ export async function xmcpHandler(request: Request): Promise<Response> {
         sendInternalServerError(res);
       }
     });
-  });
+    }
+  );
 }
 
 // Re-export auth types and handlers

--- a/packages/xmcp/src/runtime/contexts/http-request-context.ts
+++ b/packages/xmcp/src/runtime/contexts/http-request-context.ts
@@ -1,4 +1,5 @@
 import { createContext } from "../../utils/context";
+import type { McpClientInfo } from "@/types/client-info";
 
 // Headers type compatible with both Node.js IncomingHttpHeaders and Web API headers
 export type HttpHeaders = Record<string, string | string[] | undefined>;
@@ -6,6 +7,7 @@ export type HttpHeaders = Record<string, string | string[] | undefined>;
 export interface HttpRequestContext {
   id: string;
   headers: HttpHeaders;
+  clientInfo?: McpClientInfo;
 }
 
 export const httpRequestContext = createContext<HttpRequestContext>({

--- a/packages/xmcp/src/runtime/platforms/cloudflare/worker.ts
+++ b/packages/xmcp/src/runtime/platforms/cloudflare/worker.ts
@@ -1,6 +1,7 @@
 import { createServer } from "@/runtime/utils/server";
 import { WebStatelessHttpTransport } from "@/runtime/transports/http/web-stateless-http";
 import { httpRequestContextProvider } from "@/runtime/contexts/http-request-context";
+import { extractClientInfoFromMessages } from "@/runtime/utils/client-info";
 import homeTemplate from "../../templates/home";
 
 import { addCorsHeaders, handleCorsPreflightRequest } from "./cors";
@@ -48,9 +49,7 @@ async function resolveWebMiddleware(): Promise<WebMiddleware[]> {
   return resolvedMiddlewarePromise;
 }
 
-function normalizeWebMiddleware(
-  defaultExport: unknown
-): WebMiddleware[] {
+function normalizeWebMiddleware(defaultExport: unknown): WebMiddleware[] {
   if (Array.isArray(defaultExport)) {
     return defaultExport.filter(isWebMiddleware);
   }
@@ -65,9 +64,7 @@ function normalizeWebMiddleware(
     "middleware" in defaultExport &&
     typeof (defaultExport as { middleware?: unknown }).middleware === "function"
   ) {
-    return [
-      (defaultExport as { middleware: WebMiddleware }).middleware,
-    ];
+    return [(defaultExport as { middleware: WebMiddleware }).middleware];
   }
 
   return [];
@@ -122,6 +119,11 @@ async function handleMcpRequest(
   authInfo?: AuthInfo
 ): Promise<Response> {
   const requestId = crypto.randomUUID();
+  const requestPayload = await request
+    .clone()
+    .json()
+    .catch(() => undefined);
+  const clientInfo = extractClientInfoFromMessages(requestPayload);
 
   // Use the http request context provider to maintain request isolation
   return new Promise<Response>((resolve) => {
@@ -131,43 +133,46 @@ async function handleMcpRequest(
       headers[key] = value;
     });
 
-    httpRequestContextProvider({ id: requestId, headers }, async () => {
-      let server: Awaited<ReturnType<typeof createServer>> | null = null;
-      let transport: WebStatelessHttpTransport | null = null;
+    httpRequestContextProvider(
+      { id: requestId, headers, clientInfo },
+      async () => {
+        let server: Awaited<ReturnType<typeof createServer>> | null = null;
+        let transport: WebStatelessHttpTransport | null = null;
 
-      try {
-        server = await createServer();
-        transport = new WebStatelessHttpTransport(httpConfig.debug);
+        try {
+          server = await createServer();
+          transport = new WebStatelessHttpTransport(httpConfig.debug);
 
-        await server.connect(transport);
-        const response = await transport.handleRequest(request, authInfo);
+          await server.connect(transport);
+          const response = await transport.handleRequest(request, authInfo);
 
-        resolve(addCorsHeaders(response, requestOrigin));
-      } catch (error) {
-        console.error("[Cloudflare-MCP] Error handling MCP request:", error);
-        const errorResponse = new Response(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            error: {
-              code: -32603,
-              message: "Internal server error",
-            },
-            id: null,
-          }),
-          {
-            status: 500,
-            headers: { "Content-Type": "application/json" },
-          }
-        );
-        resolve(addCorsHeaders(errorResponse, requestOrigin));
-      } finally {
-        if (server && transport) {
-          ctx.waitUntil(
-            Promise.allSettled([transport.close(), server.close()])
+          resolve(addCorsHeaders(response, requestOrigin));
+        } catch (error) {
+          console.error("[Cloudflare-MCP] Error handling MCP request:", error);
+          const errorResponse = new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: -32603,
+                message: "Internal server error",
+              },
+              id: null,
+            }),
+            {
+              status: 500,
+              headers: { "Content-Type": "application/json" },
+            }
           );
+          resolve(addCorsHeaders(errorResponse, requestOrigin));
+        } finally {
+          if (server && transport) {
+            ctx.waitUntil(
+              Promise.allSettled([transport.close(), server.close()])
+            );
+          }
         }
       }
-    });
+    );
   });
 }
 

--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -21,13 +21,24 @@ import { greenCheck } from "../../../utils/cli-icons";
 import { findAvailablePort } from "../../../utils/port-utils";
 import { cors } from "./cors";
 import { Provider } from "@/runtime/middlewares/utils";
-import { httpRequestContextProvider } from "@/runtime/contexts/http-request-context";
+import {
+  httpRequestContextProvider,
+  setHttpRequestContext,
+} from "@/runtime/contexts/http-request-context";
 import {
   extractToolNamesFromRequest,
   storeToolNamesOnRequestHeaders,
 } from "@/runtime/utils/request-tool-names";
 import { CorsConfig, corsConfigSchema } from "@/compiler/config/schemas";
 import { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types";
+import { extractClientInfoFromMessages } from "@/runtime/utils/client-info";
+import type { McpClientInfo } from "@/types/client-info";
+
+interface SessionLifecycle {
+  server: McpServer;
+  transport: SdkStreamableHTTPServerTransport;
+  clientInfo?: McpClientInfo;
+}
 
 // Global type declarations for tool name context
 declare global {
@@ -99,13 +110,7 @@ export class StatelessStreamableHTTPTransport {
   private createServerFn: () => Promise<McpServer>;
   private corsConfig: CorsConfig;
   private providers: Provider[] | undefined;
-  private sessions = new Map<
-    string,
-    {
-      server: McpServer;
-      transport: SdkStreamableHTTPServerTransport;
-    }
-  >();
+  private sessions = new Map<string, SessionLifecycle>();
 
   constructor(
     createServerFn: () => Promise<McpServer>,
@@ -254,8 +259,10 @@ export class StatelessStreamableHTTPTransport {
     res: Response
   ): Promise<void> {
     try {
+      const requestClientInfo = extractClientInfoFromMessages(req.body);
       const sessionId = this.getSessionId(req);
       let lifecycle = sessionId ? this.sessions.get(sessionId) : undefined;
+      let clientInfo = requestClientInfo;
 
       res.on("finish", () => {
         global.__XMCP_CURRENT_TOOL_NAME = undefined;
@@ -265,7 +272,11 @@ export class StatelessStreamableHTTPTransport {
       });
 
       if (!lifecycle) {
-        if (sessionId || req.method !== "POST" || !isInitializeRequest(req.body)) {
+        if (
+          sessionId ||
+          req.method !== "POST" ||
+          !isInitializeRequest(req.body)
+        ) {
           res.status(400).json({
             jsonrpc: "2.0",
             error: {
@@ -280,10 +291,24 @@ export class StatelessStreamableHTTPTransport {
         lifecycle = await this.createSessionLifecycle();
       }
 
+      if (!clientInfo) {
+        clientInfo = lifecycle.clientInfo;
+      }
+
+      setHttpRequestContext({ clientInfo });
+
       await lifecycle.transport.handleRequest(req, res, req.body);
 
       if (!sessionId && lifecycle.transport.sessionId) {
-        this.sessions.set(lifecycle.transport.sessionId, lifecycle);
+        this.sessions.set(lifecycle.transport.sessionId, {
+          ...lifecycle,
+          clientInfo,
+        });
+      } else if (sessionId && lifecycle.transport.sessionId) {
+        this.sessions.set(lifecycle.transport.sessionId, {
+          ...lifecycle,
+          clientInfo,
+        });
       }
     } catch (error) {
       console.error("[HTTP-server] Error handling MCP request:", error);
@@ -307,15 +332,10 @@ export class StatelessStreamableHTTPTransport {
       return header[0];
     }
 
-    return typeof header === "string" && header.length > 0
-      ? header
-      : undefined;
+    return typeof header === "string" && header.length > 0 ? header : undefined;
   }
 
-  private async createSessionLifecycle(): Promise<{
-    server: McpServer;
-    transport: SdkStreamableHTTPServerTransport;
-  }> {
+  private async createSessionLifecycle(): Promise<SessionLifecycle> {
     const server = await this.createServerFn();
     const transport = new SdkStreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),

--- a/packages/xmcp/src/runtime/utils/__tests__/client-info.test.ts
+++ b/packages/xmcp/src/runtime/utils/__tests__/client-info.test.ts
@@ -1,0 +1,80 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import {
+  extractClientInfoFromMessage,
+  extractClientInfoFromMessages,
+} from "../client-info";
+
+test("extractClientInfoFromMessage returns undefined for non-initialize methods", () => {
+  const result = extractClientInfoFromMessage({
+    jsonrpc: "2.0",
+    method: "tools/call",
+    params: {},
+  });
+
+  assert.strictEqual(result, undefined);
+});
+
+test("extractClientInfoFromMessage extracts required and optional fields", () => {
+  const result = extractClientInfoFromMessage({
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {
+      clientInfo: {
+        name: "cursor",
+        version: "0.50.1",
+        title: "Cursor",
+        websiteUrl: "https://cursor.com",
+        description: "AI code editor",
+      },
+    },
+  });
+
+  assert.deepStrictEqual(result, {
+    name: "cursor",
+    version: "0.50.1",
+    title: "Cursor",
+    websiteUrl: "https://cursor.com",
+    description: "AI code editor",
+  });
+});
+
+test("extractClientInfoFromMessage returns undefined for invalid clientInfo payload", () => {
+  const result = extractClientInfoFromMessage({
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {
+      clientInfo: {
+        name: "cursor",
+      },
+    },
+  });
+
+  assert.strictEqual(result, undefined);
+});
+
+test("extractClientInfoFromMessages supports batch requests", () => {
+  const result = extractClientInfoFromMessages([
+    {
+      jsonrpc: "2.0",
+      method: "ping",
+      id: 1,
+    },
+    {
+      jsonrpc: "2.0",
+      method: "initialize",
+      id: 2,
+      params: {
+        clientInfo: {
+          name: "opencode",
+          version: "1.2.3",
+        },
+      },
+    },
+  ]);
+
+  assert.deepStrictEqual(result, {
+    name: "opencode",
+    version: "1.2.3",
+  });
+});

--- a/packages/xmcp/src/runtime/utils/__tests__/tool-extra.test.ts
+++ b/packages/xmcp/src/runtime/utils/__tests__/tool-extra.test.ts
@@ -1,0 +1,110 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import {
+  transformToolHandler,
+  type UserToolResponse,
+} from "../transformers/tool";
+import { httpRequestContextProvider } from "../../contexts/http-request-context";
+
+type MinimalExtra = {
+  signal: AbortSignal;
+  requestId: string;
+  sendNotification: (notification: unknown) => Promise<void>;
+  sendRequest: (request: unknown, resultSchema: unknown) => Promise<unknown>;
+};
+
+const createMinimalExtra = (requestId: string): MinimalExtra => ({
+  signal: new AbortController().signal,
+  requestId,
+  sendNotification: async () => undefined,
+  sendRequest: async () => ({}),
+});
+
+const invokeHandler = (
+  handler: unknown,
+  requestId: string
+): Promise<UserToolResponse> => {
+  const typedHandler = handler as (
+    args: Record<string, never>,
+    extra: MinimalExtra
+  ) => Promise<UserToolResponse>;
+
+  return typedHandler({}, createMinimalExtra(requestId));
+};
+
+test("transformToolHandler forwards clientInfo through tool extra arguments", async () => {
+  const transformedHandler = transformToolHandler((args, extra) => {
+    return {
+      structuredContent: {
+        ...args,
+        clientInfoName: extra.clientInfo?.name,
+        clientInfoVersion: extra.clientInfo?.version,
+      },
+    };
+  });
+
+  const result = await new Promise<UserToolResponse>((resolve, reject) => {
+    httpRequestContextProvider(
+      {
+        id: "request-id",
+        headers: {},
+        clientInfo: {
+          name: "cursor",
+          version: "0.50.1",
+          title: "Cursor",
+        },
+      },
+      () => {
+        invokeHandler(transformedHandler, "rpc-1").then(resolve).catch(reject);
+      }
+    );
+  });
+
+  assert.deepStrictEqual(result, {
+    structuredContent: {
+      clientInfoName: "cursor",
+      clientInfoVersion: "0.50.1",
+    },
+    content: [
+      {
+        type: "text",
+        text: '{"clientInfoName":"cursor","clientInfoVersion":"0.50.1"}',
+      },
+    ],
+  });
+});
+
+test("transformToolHandler leaves clientInfo undefined when request has no initialize metadata", async () => {
+  const transformedHandler = transformToolHandler((_args, extra) => {
+    return {
+      structuredContent: {
+        hasClientInfo: extra.clientInfo !== undefined,
+      },
+    };
+  });
+
+  const result = await new Promise<UserToolResponse>((resolve, reject) => {
+    httpRequestContextProvider(
+      {
+        id: "request-id-2",
+        headers: {},
+        clientInfo: undefined,
+      },
+      () => {
+        invokeHandler(transformedHandler, "rpc-2").then(resolve).catch(reject);
+      }
+    );
+  });
+
+  assert.deepStrictEqual(result, {
+    structuredContent: {
+      hasClientInfo: false,
+    },
+    content: [
+      {
+        type: "text",
+        text: '{"hasClientInfo":false}',
+      },
+    ],
+  });
+});

--- a/packages/xmcp/src/runtime/utils/client-info.ts
+++ b/packages/xmcp/src/runtime/utils/client-info.ts
@@ -1,0 +1,71 @@
+import type { JsonRpcMessage } from "@/runtime/transports/http/base-streamable-http";
+import type { McpClientInfo } from "@/types/client-info";
+
+const isObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const parseClientInfoCandidate = (
+  candidate: unknown
+): McpClientInfo | undefined => {
+  if (!isObject(candidate)) {
+    return undefined;
+  }
+
+  if (
+    typeof candidate.name !== "string" ||
+    typeof candidate.version !== "string"
+  ) {
+    return undefined;
+  }
+
+  const result: McpClientInfo = {
+    name: candidate.name,
+    version: candidate.version,
+  };
+
+  if (typeof candidate.title === "string") {
+    result.title = candidate.title;
+  }
+
+  if (typeof candidate.websiteUrl === "string") {
+    result.websiteUrl = candidate.websiteUrl;
+  }
+
+  if (typeof candidate.description === "string") {
+    result.description = candidate.description;
+  }
+
+  return result;
+};
+
+export const extractClientInfoFromMessage = (
+  message: JsonRpcMessage | undefined
+): McpClientInfo | undefined => {
+  if (!message || message.method !== "initialize") {
+    return undefined;
+  }
+
+  if (!isObject(message.params)) {
+    return undefined;
+  }
+
+  return parseClientInfoCandidate(message.params.clientInfo);
+};
+
+export const extractClientInfoFromMessages = (
+  payload: unknown
+): McpClientInfo | undefined => {
+  const messages = Array.isArray(payload)
+    ? (payload as JsonRpcMessage[])
+    : ([payload] as JsonRpcMessage[]);
+
+  for (const message of messages) {
+    const clientInfo = extractClientInfoFromMessage(message);
+    if (clientInfo) {
+      return clientInfo;
+    }
+  }
+
+  return undefined;
+};

--- a/packages/xmcp/src/runtime/utils/transformers/tool.ts
+++ b/packages/xmcp/src/runtime/utils/transformers/tool.ts
@@ -6,6 +6,7 @@ import {
 import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol";
 import { ZodRawShape } from "zod/v3";
 import type { ToolExtraArguments } from "@/types/tool";
+import { getHttpRequestContext } from "@/runtime/contexts/http-request-context";
 import { elicitFromTool } from "../elicitation";
 import { validateContent } from "../validators";
 
@@ -52,9 +53,7 @@ export type UserToolResponse =
 export type UserToolHandler = (
   args: ZodRawShape,
   extra: ToolExtraArguments
-) =>
-  | UserToolResponse
-  | Promise<UserToolResponse>;
+) => UserToolResponse | Promise<UserToolResponse>;
 
 /**
  * Type for the transformed handler that the MCP server expects
@@ -75,8 +74,17 @@ function hasUIMeta(meta?: Record<string, any>): boolean {
 function createToolExtraArguments(
   extra: RequestHandlerExtra<ServerRequest, ServerNotification>
 ): ToolExtraArguments {
+  let clientInfo = undefined;
+
+  try {
+    clientInfo = getHttpRequestContext().clientInfo;
+  } catch {
+    // no request context available (for example, stdio transport)
+  }
+
   return {
     ...(extra as ToolExtraArguments),
+    clientInfo,
     elicit: (request, options) =>
       elicitFromTool(extra as ToolExtraArguments, request, options),
   };

--- a/packages/xmcp/src/types/client-info.ts
+++ b/packages/xmcp/src/types/client-info.ts
@@ -1,0 +1,12 @@
+export interface McpClientInfo {
+  /** MCP client implementation name from initialize.params.clientInfo.name */
+  name: string;
+  /** MCP client implementation version from initialize.params.clientInfo.version */
+  version: string;
+  /** Optional human-friendly title from initialize.params.clientInfo.title */
+  title?: string;
+  /** Optional website URL from initialize.params.clientInfo.websiteUrl */
+  websiteUrl?: string;
+  /** Optional description from initialize.params.clientInfo.description */
+  description?: string;
+}

--- a/packages/xmcp/src/types/tool.ts
+++ b/packages/xmcp/src/types/tool.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v3";
 import type { ZodType as ZodTypeV4, infer as inferV4 } from "zod";
 import type { ElicitResult as McpElicitResult } from "@modelcontextprotocol/sdk/types";
 import { UIMetadata } from "./ui-meta";
+import type { McpClientInfo } from "./client-info";
 
 export interface ToolAnnotations {
   /** Human-readable title for the tool */
@@ -119,7 +120,8 @@ export interface ElicitUrlRequest {
 
 export type ElicitRequest = ElicitFormRequest | ElicitUrlRequest;
 
-// The ToolExtraArguments type is equivalent to Parameters<ToolCallback<undefined>>[0] from @modelcontextprotocol/sdk but fully resolved to avoid external type dependencies.
+// The ToolExtraArguments type is based on Parameters<ToolCallback<undefined>>[0]
+// from @modelcontextprotocol/sdk, with xmcp-specific extensions.
 /**
  * Extra arguments passed to MCP tool functions.
  */
@@ -160,6 +162,9 @@ export interface ToolExtraArguments {
     /** The headers of the request */
     headers: Record<string, string | string[] | undefined>;
   };
+
+  /** MCP client metadata from initialize.params.clientInfo, when available */
+  clientInfo?: McpClientInfo;
 
   /** Sends a notification that relates to the current request being handled */
   sendNotification: (notification: any) => Promise<void>;


### PR DESCRIPTION
This PR adds `clientInfo` to the tool `extra` context, pulled from the MCP `initialize` payload.

Right now, if you want to know which MCP client is calling a server, you usually end up with env/argv/header heuristics. Those work until they don't. This change uses protocol data instead, so tools can rely on `extra.clientInfo` when it's available.

### What changed

- Added a shared `McpClientInfo` type and exported it from `xmcp`.
- Extended `ToolExtraArguments` with optional `clientInfo`.
- Added a small parser utility for `initialize.params.clientInfo`.
- Wired propagation through HTTP paths (Express, NestJS, Next.js, Cloudflare, and streamable HTTP transport).
- Preserved `clientInfo` across streamable HTTP session lifecycle, so post-initialize calls in the same session still receive it.
- Added focused tests for extraction and tool-context exposure.
- Updated docs/examples so users can see and verify `extra.clientInfo` quickly.

### Commit breakdown

1. `feat: add clientInfo typing and initialize parser`
2. `feat: propagate clientInfo into tool execution context`
3. `test: cover clientInfo extraction and tool extra exposure`
4. `docs: document extra.clientInfo and refresh examples`

### Validation

- `pnpm --filter xmcp build`
- `node --import tsx --test "src/runtime/utils/__tests__/*.test.ts"`

Build and tests pass locally.

There is still an existing non-blocking Rspack warning from `express` dynamic require, unrelated to this PR.