### PR TITLE
feat(adapters): add Fastify adapter

### DIFF
--- a/apps/website/content/docs/adapters/fastify.mdx
+++ b/apps/website/content/docs/adapters/fastify.mdx
@@ -1,0 +1,122 @@
+---
+title: "Fastify"
+metadataTitle: "Usage with Fastify | xmcp Documentation"
+publishedAt: "2026-04-16"
+summary: "Learn how to use xmcp with Fastify to build and deploy MCP servers."
+description: "Run an xmcp MCP server on Fastify. Works on any Node.js deployment target including AWS Lambda."
+---
+
+## Installation
+
+`xmcp` can work on top of your existing Fastify project. To get started, run the following command in your project directory:
+
+```bash
+npx init-xmcp@latest
+```
+
+After setting up the project, your build command should look like this:
+
+```json
+{
+  "scripts": {
+    "build": "xmcp build && tsc"
+  }
+}
+```
+
+`xmcp build` bundles your tools into `.xmcp/adapter`.
+
+## Usage
+
+Install Fastify and register the MCP handler on your server:
+
+```bash
+npm install fastify
+```
+
+```typescript
+import Fastify from "fastify";
+import { xmcpHandler } from "@xmcp/adapter";
+
+const app = Fastify({ logger: false });
+
+app.post("/mcp", xmcpHandler);
+app.get("/mcp", xmcpHandler); // required for SSE / streaming clients
+
+await app.listen({ port: 3000 });
+```
+
+<Callout variant="info">
+  For browser-origin clients, add CORS and preflight handling at the Fastify app
+  level (e.g. `@fastify/cors`). The `xmcpHandler` handles the MCP endpoint only
+  — it does not register an OPTIONS route.
+</Callout>
+
+## AWS Lambda
+
+Use `@fastify/aws-lambda` as the Lambda bridge:
+
+```bash
+npm install fastify @fastify/aws-lambda
+```
+
+```typescript
+import Fastify from "fastify";
+import awsLambdaFastify from "@fastify/aws-lambda";
+import { xmcpHandler } from "@xmcp/adapter";
+
+const app = Fastify({ logger: false });
+
+app.post("/mcp", xmcpHandler);
+
+export const handler = awsLambdaFastify(app);
+```
+
+The default buffered form (`awsLambdaFastify(app)`) works for all JSON-RPC POST requests (`initialize`, `tools/call`, etc.). GET/SSE is not supported in buffered mode — see the streaming form below.
+
+### SSE support on Lambda
+
+To support SSE via `GET /mcp`, use a Lambda Function URL with `InvokeMode: RESPONSE_STREAM` and switch to the streaming form:
+
+```typescript
+import Fastify from "fastify";
+import awsLambdaFastify from "@fastify/aws-lambda";
+import { xmcpHandler } from "@xmcp/adapter";
+import { promisify } from "node:util";
+import stream from "node:stream";
+
+const pipeline = promisify(stream.pipeline);
+const app = Fastify({ logger: false });
+
+app.post("/mcp", xmcpHandler);
+app.get("/mcp", xmcpHandler);
+
+const proxy = awsLambdaFastify(app, { payloadAsStream: true });
+
+export const handler = awslambda.streamifyResponse(
+  async (event, responseStream, context) => {
+    const { meta, stream: bodyStream } = await proxy(event, context);
+    responseStream = awslambda.HttpResponseStream.from(responseStream, meta);
+    await pipeline(bodyStream, responseStream);
+  }
+);
+```
+
+<Callout variant="info">
+  `middleware.ts` is not supported in adapter mode.
+</Callout>
+
+## xmcp.config.ts
+
+```typescript
+import type { XmcpConfig } from "xmcp";
+
+const config: XmcpConfig = {
+  http: true,
+  experimental: {
+    adapter: "fastify",
+  },
+};
+
+export default config;
+```

--- a/apps/website/content/docs/adapters/meta.json
+++ b/apps/website/content/docs/adapters/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Adapters",
-  "pages": ["nextjs", "nestjs", "express"],
+  "pages": ["nextjs", "nestjs", "express", "fastify"],
   "defaultOpen": true,
   "root": true
 }

--- a/examples/with-fastify/.gitignore
+++ b/examples/with-fastify/.gitignore
@@ -1,0 +1,3 @@
+.xmcp
+xmcp-env.d.ts
+dist

--- a/examples/with-fastify/package.json
+++ b/examples/with-fastify/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "with-fastify",
+  "description": "Build a Fastify server with xmcp's adapter",
+  "scripts": {
+    "dev": "xmcp dev & tsx watch src/index.ts",
+    "build": "xmcp build && tsx src/index.ts",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "fastify": "^5.0.0",
+    "zod": "^4.0.10"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.2",
+    "tsx": "^4.19.4",
+    "typescript": "^5.9.3",
+    "xmcp": "workspace:*"
+  },
+  "keywords": [
+    "adapter"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/examples/with-fastify/src/index.ts
+++ b/examples/with-fastify/src/index.ts
@@ -1,0 +1,18 @@
+import Fastify from "fastify";
+import { xmcpHandler } from "@xmcp/adapter";
+
+const app = Fastify({ logger: false });
+const port = 3000;
+
+app.post("/mcp", xmcpHandler);
+app.get("/mcp", xmcpHandler);
+
+app.listen({ port }, (err, address) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  console.log(`Server running at ${address}`);
+});
+
+export default app;

--- a/examples/with-fastify/src/tools/greet.ts
+++ b/examples/with-fastify/src/tools/greet.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+
+export const schema = {
+  name: z.string().describe("The name of the user to greet"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "greet",
+  description: "Greet the user",
+  annotations: {
+    title: "Greet the user",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+};
+
+export default async function greet({ name }: InferSchema<typeof schema>) {
+  return `Hello, ${name}!`;
+}

--- a/examples/with-fastify/tsconfig.json
+++ b/examples/with-fastify/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@xmcp/*": ["./.xmcp/*"]
+    }
+  },
+  "include": ["src/**/*", "xmcp-env.d.ts"]
+}

--- a/examples/with-fastify/xmcp.config.ts
+++ b/examples/with-fastify/xmcp.config.ts
@@ -1,0 +1,14 @@
+import type { XmcpConfig } from "xmcp";
+
+const config: XmcpConfig = {
+  http: true,
+  experimental: {
+    adapter: "fastify",
+  },
+  paths: {
+    prompts: false,
+    resources: false,
+  },
+};
+
+export default config;

--- a/packages/init-xmcp/src/helpers/detect-framework.ts
+++ b/packages/init-xmcp/src/helpers/detect-framework.ts
@@ -3,7 +3,7 @@ import fs from "fs-extra";
 import path from "path";
 import { readTsConfigFile } from "../utils/read-config-file.js";
 
-export type Framework = "nextjs" | "nestjs" | "express";
+export type Framework = "nextjs" | "nestjs" | "express" | "fastify";
 
 export function detectFramework(projectRoot: string): Framework {
   const packageJson = JSON.parse(
@@ -11,13 +11,24 @@ export function detectFramework(projectRoot: string): Framework {
   );
 
   // Check for NestJS
-  if (packageJson.dependencies?.["@nestjs/core"] || packageJson.devDependencies?.["@nestjs/core"]) {
+  if (
+    packageJson.dependencies?.["@nestjs/core"] ||
+    packageJson.devDependencies?.["@nestjs/core"]
+  ) {
     return "nestjs";
   }
 
   // Check for Next.js
   if (packageJson.dependencies?.next || packageJson.devDependencies?.next) {
     return "nextjs";
+  }
+
+  // Check for Fastify
+  if (
+    packageJson.dependencies?.fastify ||
+    packageJson.devDependencies?.fastify
+  ) {
+    return "fastify";
   }
 
   // Default to express

--- a/packages/init-xmcp/src/index.ts
+++ b/packages/init-xmcp/src/index.ts
@@ -365,7 +365,7 @@ const program = new Command()
       console.log(chalk.blue("\nNext steps:"));
 
       // code integration for express projects
-      if (detectedFramework !== "nextjs" && detectedFramework !== "nestjs") {
+      if (detectedFramework === "express") {
         const integrationCode = `import { xmcpHandler } from '@xmcp/adapter';
 
 myApp.post("/mcp", xmcpHandler);
@@ -383,6 +383,32 @@ myApp.get("/mcp", xmcpHandler);`;
           console.log(chalk.green(chalk.bgBlack(`  ${line}${padding}`)));
         });
         console.log(chalk.green(chalk.bgBlack(`  ${" ".repeat(maxLength)}`)));
+      }
+
+      // code integration for Fastify projects
+      if (detectedFramework === "fastify") {
+        const integrationCode = `import { xmcpHandler } from '@xmcp/adapter';
+
+app.post("/mcp", xmcpHandler);
+app.get("/mcp", xmcpHandler);`;
+
+        const lines = integrationCode.split("\n");
+        const maxLength = Math.max(...lines.map((line) => line.length)) + 2;
+
+        console.log(
+          "\nTo get started with the xmcpHandler in your Fastify application, add this code to your server:\n"
+        );
+        console.log(chalk.green(chalk.bgBlack(`  ${" ".repeat(maxLength)}`)));
+        lines.forEach((line) => {
+          const padding = " ".repeat(maxLength - line.length);
+          console.log(chalk.green(chalk.bgBlack(`  ${line}${padding}`)));
+        });
+        console.log(chalk.green(chalk.bgBlack(`  ${" ".repeat(maxLength)}`)));
+        console.log(
+          chalk.yellow(
+            "\nNote: for browser clients, add CORS and OPTIONS handling at the app level (e.g. @fastify/cors).\n"
+          )
+        );
       }
 
       // code integration for NestJS projects

--- a/packages/xmcp/bundler/build-runtime.ts
+++ b/packages/xmcp/bundler/build-runtime.ts
@@ -19,7 +19,7 @@ interface RuntimeRoot {
   path: string;
 }
 
-// Node.js runtime roots (express, nextjs adapters + transports)
+// Node.js runtime roots (adapters + transports)
 const runtimeRoots: RuntimeRoot[] = [
   { name: "headers", path: "headers" },
   { name: "stdio", path: "transports/stdio" },
@@ -27,6 +27,7 @@ const runtimeRoots: RuntimeRoot[] = [
   { name: "adapter-express", path: "adapters/express" },
   { name: "adapter-nextjs", path: "adapters/nextjs" },
   { name: "adapter-nestjs", path: "adapters/nestjs" },
+  { name: "adapter-fastify", path: "adapters/fastify" },
 ];
 
 const entry: EntryObject = {};
@@ -34,7 +35,7 @@ for (const root of runtimeRoots) {
   entry[root.name] = path.join(srcPath, "runtime", root.path);
 }
 
-// Node.js config (express, nextjs, http, stdio)
+// Node.js runtime bundle config
 const config: RspackOptions = {
   name: "runtime-node",
   entry,
@@ -45,6 +46,7 @@ const config: RspackOptions = {
   externals: {
     "@rspack/core": "@rspack/core",
     "@nestjs/common": "@nestjs/common",
+    fastify: "fastify",
   },
   output: {
     filename: "[name].js",

--- a/packages/xmcp/package.json
+++ b/packages/xmcp/package.json
@@ -73,7 +73,8 @@
     "dev": "cross-env NODE_ENV=development tsx --watch --tsconfig ./bundler.tsconfig.json ./bundler/index.ts",
     "build": "cross-env NODE_ENV=production tsx --tsconfig ./bundler.tsconfig.json ./bundler/index.ts",
     "analyze": "cross-env GENERATE_STATS=true pnpm build && pnpm tsx scripts/analyze-rspack-stats.ts",
-    "test:config": "node --import tsx --test src/compiler/config/__tests__/*.test.ts"
+    "test:config": "node --import tsx --test src/compiler/config/__tests__/*.test.ts",
+    "test:adapters": "node --import tsx --test src/runtime/adapters/fastify/__tests__/*.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
@@ -103,6 +104,7 @@
     "del": "^7.1.0",
     "dotenv": "^16.6.1",
     "express": "^4.22.1",
+    "fastify": "^5.0.0",
     "fs-extra": "^11.3.2",
     "glob": "^11.1.0",
     "is-docker": "^4.0.0",

--- a/packages/xmcp/src/compiler/config/__tests__/config.test.ts
+++ b/packages/xmcp/src/compiler/config/__tests__/config.test.ts
@@ -169,6 +169,27 @@ describe("Config System - Resolution Functions", () => {
 
     assert.equal(resolved.adapter, "express");
   });
+
+  it("should resolve fastify adapter", () => {
+    const config = configSchema.parse({
+      experimental: {
+        adapter: "fastify",
+      },
+    });
+    const resolved = getResolvedExperimentalConfig(config);
+
+    assert.equal(resolved.adapter, "fastify");
+  });
+
+  it("should reject unknown adapter values", () => {
+    assert.throws(() => {
+      configSchema.parse({
+        experimental: {
+          adapter: "unknown-framework",
+        },
+      });
+    });
+  });
 });
 
 describe("Config System - Injection Functions", () => {

--- a/packages/xmcp/src/compiler/config/schemas/experimental/index.ts
+++ b/packages/xmcp/src/compiler/config/schemas/experimental/index.ts
@@ -3,7 +3,12 @@ import { z } from "zod/v3";
 // ------------------------------------------------------------
 // Adapter config schema (perhaps a separate file but it's small yet)
 // ------------------------------------------------------------
-export const adapterConfigSchema = z.enum(["express", "nextjs", "nestjs"]);
+export const adapterConfigSchema = z.enum([
+  "express",
+  "nextjs",
+  "nestjs",
+  "fastify",
+]);
 
 export type AdapterConfig = z.infer<typeof adapterConfigSchema>;
 

--- a/packages/xmcp/src/compiler/get-bundler-config/get-entries.ts
+++ b/packages/xmcp/src/compiler/get-bundler-config/get-entries.ts
@@ -36,6 +36,9 @@ export function getEntries(
     if (xmcpConfig.experimental?.adapter === "nestjs") {
       entries["adapter"] = path.join(runtimeFolderPath, "adapter-nestjs.js");
     }
+    if (xmcpConfig.experimental?.adapter === "fastify") {
+      entries["adapter"] = path.join(runtimeFolderPath, "adapter-fastify.js");
+    }
   }
   return entries;
 }

--- a/packages/xmcp/src/compiler/get-bundler-config/get-externals.ts
+++ b/packages/xmcp/src/compiler/get-bundler-config/get-externals.ts
@@ -75,6 +75,16 @@ export function getExternals(): RspackOptions["externals"] {
       }
 
       /**
+       * When using Fastify, externalize fastify since it should come from
+       * the user's node_modules
+       */
+      if (xmcpConfig.experimental?.adapter === "fastify") {
+        if (request === "fastify" || request.startsWith("fastify/")) {
+          return callback(undefined, `commonjs ${request}`);
+        }
+      }
+
+      /**
        * When using NestJS, externalize NestJS-related packages
        * since they should come from the user's node_modules
        */

--- a/packages/xmcp/src/compiler/get-bundler-config/plugins/index.ts
+++ b/packages/xmcp/src/compiler/get-bundler-config/plugins/index.ts
@@ -6,6 +6,7 @@ import { XmcpConfigOutputSchema } from "@/compiler/config";
 import { getXmcpConfig } from "@/compiler/compiler-context";
 import {
   expressTypeDefinition,
+  fastifyTypeDefinition,
   nestJsTypeDefinition,
   nextJsTypeDefinition,
 } from "./types";
@@ -70,6 +71,8 @@ function getNeededRuntimeFiles(xmcpConfig: XmcpConfigOutputSchema): string[] {
       neededFiles.push("adapter-nextjs.js");
     } else if (xmcpConfig.experimental?.adapter === "nestjs") {
       neededFiles.push("adapter-nestjs.js");
+    } else if (xmcpConfig.experimental?.adapter === "fastify") {
+      neededFiles.push("adapter-fastify.js");
     } else {
       neededFiles.push("http.js");
     }
@@ -117,12 +120,14 @@ export class CreateTypeDefinitionPlugin {
         // Manually type the .xmcp/adapter/index.js file using a .xmcp/adapter/index.d.ts file
         if (xmcpConfig.experimental?.adapter) {
           let typeDefinitionContent = "";
-          if (xmcpConfig.experimental?.adapter == "nextjs") {
+          if (xmcpConfig.experimental?.adapter === "nextjs") {
             typeDefinitionContent = nextJsTypeDefinition;
-          } else if (xmcpConfig.experimental?.adapter == "express") {
+          } else if (xmcpConfig.experimental?.adapter === "express") {
             typeDefinitionContent = expressTypeDefinition;
-          } else if (xmcpConfig.experimental?.adapter == "nestjs") {
+          } else if (xmcpConfig.experimental?.adapter === "nestjs") {
             typeDefinitionContent = nestJsTypeDefinition;
+          } else if (xmcpConfig.experimental?.adapter === "fastify") {
+            typeDefinitionContent = fastifyTypeDefinition;
           }
           fs.writeFileSync(
             path.join(adapterOutputPath, "index.d.ts"),

--- a/packages/xmcp/src/compiler/get-bundler-config/plugins/types/fastify.ts
+++ b/packages/xmcp/src/compiler/get-bundler-config/plugins/types/fastify.ts
@@ -1,0 +1,4 @@
+export const fastifyTypeDefinition = `
+import type { FastifyRequest, FastifyReply } from 'fastify';
+export declare function xmcpHandler(request: FastifyRequest, reply: FastifyReply): Promise<void>;
+`;

--- a/packages/xmcp/src/compiler/get-bundler-config/plugins/types/index.ts
+++ b/packages/xmcp/src/compiler/get-bundler-config/plugins/types/index.ts
@@ -2,3 +2,4 @@
 export { nextJsTypeDefinition } from "./next";
 export { expressTypeDefinition } from "./express";
 export { nestJsTypeDefinition } from "./nest";
+export { fastifyTypeDefinition } from "./fastify";

--- a/packages/xmcp/src/runtime/adapters/fastify/__tests__/fastify.test.ts
+++ b/packages/xmcp/src/runtime/adapters/fastify/__tests__/fastify.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, before } from "node:test";
+import assert from "node:assert";
+import Fastify from "fastify";
+
+// All DefinePlugin globals must be set before the adapter and server modules are
+// loaded. HTTP_CONFIG and HTTP_CORS_CONFIG are captured at module evaluation
+// time inside the adapter; INJECTED_* and SERVER_INFO are captured in
+// utils/server.ts. The modules are loaded via dynamic import() inside before(),
+// which runs after this synchronous initialisation.
+const g = globalThis as Record<string, unknown>;
+g["HTTP_CONFIG"] = {
+  port: 3001,
+  host: "127.0.0.1",
+  bodySizeLimit: 10 * 1024 * 1024,
+  endpoint: "/mcp",
+  debug: false,
+};
+g["HTTP_CORS_CONFIG"] = {
+  origin: "*",
+  methods: ["GET", "POST"],
+  credentials: false,
+  maxAge: 86400,
+};
+g["INJECTED_TOOLS"] = {};
+g["INJECTED_PROMPTS"] = {};
+g["INJECTED_RESOURCES"] = {};
+g["SERVER_INFO"] = { name: "test-server", version: "0.0.0" };
+
+const HEADERS = {
+  "content-type": "application/json",
+  accept: "text/event-stream, application/json",
+};
+
+describe("Fastify adapter", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let xmcpHandler!: (req: any, reply: any) => Promise<void>;
+  let injectedTools!: Record<string, () => Promise<unknown>>;
+
+  before(async () => {
+    // Dynamically import AFTER globals are set so module-level initialisers see
+    // the correct values.
+    ({ xmcpHandler } = (await import("../index")) as {
+      xmcpHandler: typeof xmcpHandler;
+    });
+    ({ injectedTools } = (await import("../../../utils/server")) as {
+      injectedTools: Record<string, () => Promise<unknown>>;
+    });
+  });
+
+  it("handles an initialize request successfully", async () => {
+    const app = Fastify();
+    app.post("/mcp", xmcpHandler);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/mcp",
+      headers: HEADERS,
+      payload: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      },
+    });
+
+    assert.strictEqual(response.statusCode, 200);
+    assert.ok(
+      response.body.includes('"serverInfo"'),
+      'response body must contain "serverInfo"'
+    );
+    assert.ok(
+      response.body.includes("test-server"),
+      "response body must contain the server name"
+    );
+  });
+
+  it("writes a 500 JSON-RPC error to reply.raw when createServer throws", async () => {
+    // Inject a broken loader into the live injectedTools object so that the next
+    // loadToolModules() call rejects, propagating up through createServer() and
+    // into the catch block inside xmcpHandler. This works because injectedTools
+    // is the same object reference that was captured from INJECTED_TOOLS above —
+    // adding a key here is visible to loadTools() on the next invocation.
+    injectedTools["__test_error__"] = async () => {
+      throw new Error("forced load failure");
+    };
+
+    try {
+      const app = Fastify();
+      app.post("/mcp", xmcpHandler);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/mcp",
+        headers: HEADERS,
+        payload: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      });
+
+      // After reply.hijack() the catch block writes directly to reply.raw.
+      assert.strictEqual(response.statusCode, 500);
+      const body = JSON.parse(response.body) as {
+        jsonrpc: string;
+        error: { code: number; message: string };
+        id: unknown;
+      };
+      assert.strictEqual(body.jsonrpc, "2.0");
+      assert.strictEqual(body.error.code, -32603);
+    } finally {
+      delete injectedTools["__test_error__"];
+    }
+  });
+});

--- a/packages/xmcp/src/runtime/adapters/fastify/index.ts
+++ b/packages/xmcp/src/runtime/adapters/fastify/index.ts
@@ -1,0 +1,78 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import { createServer } from "@/runtime/utils/server";
+import { StatelessHttpServerTransport } from "@/runtime/transports/http/stateless-streamable-http";
+import { setHeaders } from "@/runtime/transports/http/cors";
+import { httpRequestContextProvider } from "@/runtime/contexts/http-request-context";
+import { randomUUID } from "node:crypto";
+import { extractClientInfoFromMessages } from "@/runtime/utils/client-info";
+import type { CorsConfig } from "@/compiler/config";
+
+const httpConfig = HTTP_CONFIG as {
+  port: number;
+  host: string;
+  bodySizeLimit: number;
+  endpoint: string;
+  debug: boolean;
+};
+const corsConfig = HTTP_CORS_CONFIG as CorsConfig;
+
+export async function xmcpHandler(
+  request: FastifyRequest,
+  reply: FastifyReply
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const id = randomUUID();
+    const clientInfo = extractClientInfoFromMessages(request.body);
+
+    httpRequestContextProvider(
+      { id, headers: request.headers, clientInfo },
+      async () => {
+        try {
+          // Claim the raw stream before any await so Fastify never attempts its
+          // own finalisation after the transport has already written to reply.raw.
+          // This MUST remain the first statement in the try block — after hijack,
+          // any throw is caught here and written directly to reply.raw, with no
+          // risk of Fastify also sending a response.
+          reply.hijack();
+
+          setHeaders(reply.raw, corsConfig, request.headers.origin);
+
+          const server = await createServer();
+          const transport = new StatelessHttpServerTransport(
+            httpConfig.debug,
+            httpConfig.bodySizeLimit.toString()
+          );
+
+          // Release transport + server when the connection closes (normal
+          // completion or client abort). Without this, warm containers leak
+          // instances per request.
+          reply.raw.on("close", () => {
+            transport.close();
+            server.close();
+          });
+
+          await server.connect(transport);
+
+          // The transport writes directly to reply.raw via Node's ServerResponse
+          // API. request.raw has already had its body consumed by Fastify, so
+          // we pass request.body as parsedBody rather than re-reading the stream.
+          await transport.handleRequest(request.raw, reply.raw, request.body);
+          resolve();
+        } catch (error) {
+          console.error("[HTTP-server] Error handling MCP request:", error);
+          if (!reply.raw.headersSent) {
+            reply.raw.writeHead(500, { "content-type": "application/json" });
+            reply.raw.end(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                error: { code: -32603, message: "Internal server error" },
+                id: null,
+              })
+            );
+          }
+          resolve();
+        }
+      }
+    );
+  });
+}

--- a/packages/xmcp/src/runtime/transports/http/cors/index.ts
+++ b/packages/xmcp/src/runtime/transports/http/cors/index.ts
@@ -1,12 +1,14 @@
 import { CorsConfig } from "@/compiler/config";
+import { ServerResponse } from "http";
 import { Request, Response, NextFunction, RequestHandler } from "express";
 import { buildCorsHeaders } from "./headers";
 
 /**
- * Sets CORS headers on the response based on the provided configuration
+ * Sets CORS headers on the response based on the provided configuration.
+ * Accepts any Node ServerResponse (or Express Response, which extends it).
  */
 export function setHeaders(
-  res: Response,
+  res: ServerResponse,
   config: CorsConfig,
   origin?: string
 ): void {

--- a/packages/xmcp/src/telemetry/events/definitions.ts
+++ b/packages/xmcp/src/telemetry/events/definitions.ts
@@ -23,6 +23,8 @@ export enum AdapterType {
   NONE = "none",
   EXPRESS = "express",
   NEXTJS = "nextjs",
+  NESTJS = "nestjs",
+  FASTIFY = "fastify",
 }
 
 type EventPayload = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,6 +729,28 @@ importers:
         specifier: workspace:*
         version: link:../../packages/xmcp
 
+  examples/with-fastify:
+    dependencies:
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.5
+      zod:
+        specifier: ^4.0.10
+        version: 4.1.13
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.2
+        version: 22.19.2
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      xmcp:
+        specifier: workspace:*
+        version: link:../../packages/xmcp
+
   examples/with-nestjs:
     dependencies:
       '@nestjs/common':
@@ -1074,10 +1096,6 @@ importers:
       react-router-dom:
         specifier: ^7.13.0
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-    optionalDependencies:
-      pg:
-        specifier: ^8.16.3
-        version: 8.16.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -1130,6 +1148,10 @@ importers:
       xmcp:
         specifier: workspace:*
         version: link:../../xmcp
+    optionalDependencies:
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
 
   packages/plugins/clerk:
     dependencies:
@@ -1324,6 +1346,9 @@ importers:
       express:
         specifier: ^4.22.1
         version: 4.22.1
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.5
       fs-extra:
         specifier: ^11.3.2
         version: 11.3.2
@@ -2177,6 +2202,24 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
@@ -2829,6 +2872,9 @@ packages:
   '@peculiar/webcrypto@1.5.0':
     resolution: {integrity: sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==}
     engines: {node: '>=10.12.0'}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -4491,6 +4537,9 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -4682,6 +4731,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   attr-accept@2.2.5:
     resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
     engines: {node: '>=4'}
@@ -4704,6 +4757,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
@@ -5674,6 +5730,9 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -5691,8 +5750,14 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -5702,6 +5767,9 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -5748,6 +5816,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -6251,6 +6323,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
+
   iron-session@6.3.1:
     resolution: {integrity: sha512-3UJ7y2vk/WomAtEySmPgM6qtYF1cZ3tXuWX5GsVX4PJXAcs5y/sV9HuSfpjKS6HkTL/OhZcTDWJNLZ7w+Erx3A==}
     engines: {node: '>=12'}
@@ -6545,6 +6621,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -6633,6 +6712,9 @@ packages:
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -7262,6 +7344,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -7429,6 +7515,16 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -7555,6 +7651,12 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   promise-worker-transferable@1.0.4:
     resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
@@ -7591,6 +7693,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -7770,6 +7875,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
 
@@ -7870,6 +7979,10 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -7931,6 +8044,14 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-regex2@5.1.0:
+    resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
+    hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -7954,6 +8075,9 @@ packages:
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -8069,6 +8193,9 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8338,6 +8465,10 @@ packages:
     peerDependencies:
       tslib: ^2
 
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
+
   three-mesh-bvh@0.8.3:
     resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
     peerDependencies:
@@ -8369,6 +8500,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -9653,6 +9788,29 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
+
   '@floating-ui/core@1.7.3':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -10346,6 +10504,8 @@ snapshots:
       pvtsutils: 1.3.6
       tslib: 2.8.1
       webcrypto-core: 1.8.1
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgr/core@0.2.9': {}
 
@@ -12069,6 +12229,8 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  abstract-logging@2.0.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -12271,6 +12433,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   attr-accept@2.2.5: {}
 
   auth0@4.37.0:
@@ -12298,6 +12462,11 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.19.1
 
   axe-core@4.11.0: {}
 
@@ -13189,7 +13358,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -13210,7 +13379,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13513,6 +13682,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -13535,13 +13706,44 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
 
   fast-safe-stringify@2.1.1: {}
 
   fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
+
+  fastify@5.8.5:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.3
+      toad-cache: 3.7.0
 
   fastq@1.19.1:
     dependencies:
@@ -13607,6 +13809,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.0
 
   find-up@5.0.0:
     dependencies:
@@ -14229,6 +14437,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.3.0: {}
+
   iron-session@6.3.1(express@4.22.1)(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
       '@peculiar/webcrypto': 1.5.0
@@ -14488,6 +14698,10 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -14594,6 +14808,12 @@ snapshots:
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -15493,6 +15713,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -15678,6 +15900,26 @@ snapshots:
 
   pify@2.3.0: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
   pirates@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
@@ -15788,6 +16030,10 @@ snapshots:
 
   prettier@3.7.4: {}
 
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
+
   promise-worker-transferable@1.0.4:
     dependencies:
       is-promise: 2.2.2
@@ -15825,6 +16071,8 @@ snapshots:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -16041,6 +16289,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  real-require@0.2.0: {}
+
   recma-build-jsx@1.0.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -16209,6 +16459,8 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  ret@0.5.0: {}
+
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
@@ -16302,6 +16554,12 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-regex2@5.1.0:
+    dependencies:
+      ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   scheduler@0.25.0: {}
@@ -16329,6 +16587,8 @@ snapshots:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
+
+  secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
 
@@ -16543,6 +16803,10 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
 
   source-map-js@1.2.1: {}
 
@@ -16861,6 +17125,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
   three-mesh-bvh@0.8.3(three@0.178.0):
     dependencies:
       three: 0.178.0
@@ -16894,6 +17162,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 


### PR DESCRIPTION
Closes #562

Adds `experimental: { adapter: 'fastify' }` for deploying xmcp tools on any Fastify server. Follows the same two-stage build pattern as the existing adapters (runtime compiled to `dist/runtime/adapter-fastify.js`, embedded in `RUNTIME_FILES`, staged and bundled at user build time).

## Implementation notes

The adapter is structurally identical to Express — `StatelessHttpServerTransport` takes a raw `IncomingMessage` + `ServerResponse`, which Fastify exposes as `request.raw` and `reply.raw`. One non-obvious constraint: `reply.hijack()` must be the first call before any `await`. Without it, Fastify's error handler races the transport's writes to `reply.raw` on failure and sends a double response. This ordering is documented in the inline comment.

Uses `HTTP_CONFIG` / `HTTP_CORS_CONFIG` globals (same as NestJS), not the legacy per-variable pattern still in the Express adapter.

## Changes to shared code

**`src/runtime/transports/http/cors/index.ts`** — `setHeaders` was typed `res: express.Response`. Widened to `res: ServerResponse` (Node `http`). `express.Response` extends `ServerResponse`, so all existing callers are unaffected. Required for the Fastify adapter; also benefits any future non-Express adapter.

**`src/telemetry/events/definitions.ts`** — Added `FASTIFY` to `AdapterType`. Also added `NESTJS`, which was missing from the enum (NestJS emitted via a raw string cast, so no runtime behavior changes, just closing the gap).

**`packages/init-xmcp`** — Added Fastify framework detection and a Fastify-specific integration snippet showing both POST and GET routes.

## AWS Lambda

The adapter also works on AWS Lambda via `@fastify/aws-lambda`. Buffered mode supports all JSON-RPC POST requests; SSE via GET requires a Lambda Function URL with `InvokeMode: RESPONSE_STREAM`. Both paths are documented in `fastify.mdx`.

## Verifying

```bash
# packages/xmcp — adapter-fastify.js should appear in dist/runtime/
pnpm build && ls dist/runtime/ | grep fastify

# examples/with-fastify
xmcp build && tsc --noEmit

# config schema tests (fastify + unknown adapter rejection now covered)
node --import tsx --test src/compiler/config/__tests__/*.test.ts
```

## Note on docs

The PR template suggests targeting `main` for documentation changes. This PR includes `apps/website/content/docs/adapters/fastify.mdx` alongside the adapter code — splitting a feature and its reference page across two PRs targeting different branches felt wrong, so I've kept them together here targeting `canary`. Happy to split it out if you'd prefer.