### PR TITLE
Expose stdio clientInfo in tool extra context

### DIFF
--- a/apps/website/content/docs/core-concepts/tools.mdx
+++ b/apps/website/content/docs/core-concepts/tools.mdx
@@ -254,7 +254,7 @@ export default async function calculate({
 
 Tool handlers also receive an `extra` argument. Use `extra.elicit()` when you want the client to collect a small piece of user input before the tool continues.
 
-When your server is called over HTTP and the client sends an MCP `initialize` request, `extra.clientInfo` is available with protocol-level client identity (`name`, `version`, and optional fields like `title`).
+When the client sends an MCP `initialize` request, `extra.clientInfo` is available with protocol-level client identity (`name`, `version`, and optional fields like `title`). This is available for HTTP transports and stdio (after initialization completes).
 
 ```typescript title="src/tools/preview-elicitation.ts"
 import { type ToolExtraArguments, type ToolMetadata } from "xmcp";
@@ -573,4 +573,3 @@ The generated file already includes the basic exports you need to continue:
 - prompts: `schema`, `metadata`, and a default function
 
 So instead of starting from an empty file, you get a ready-to-edit template with placeholder descriptions and example return values.
-

--- a/packages/xmcp/src/runtime/contexts/client-info-context.ts
+++ b/packages/xmcp/src/runtime/contexts/client-info-context.ts
@@ -1,0 +1,16 @@
+import type { McpClientInfo } from "@/types/client-info";
+import { createContext } from "../../utils/context";
+
+export interface ClientInfoContext {
+  clientInfo?: McpClientInfo;
+}
+
+export const clientInfoContext = createContext<ClientInfoContext>({
+  name: "client-info-context",
+});
+
+export const setClientInfoContext = clientInfoContext.setContext;
+
+export const getClientInfoContext = clientInfoContext.getContext;
+
+export const clientInfoContextProvider = clientInfoContext.provider;

--- a/packages/xmcp/src/runtime/transports/stdio/index.ts
+++ b/packages/xmcp/src/runtime/transports/stdio/index.ts
@@ -2,6 +2,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "../../utils/server";
 import dotenv from "dotenv";
+import {
+  clientInfoContextProvider,
+  setClientInfoContext,
+} from "@/runtime/contexts/client-info-context";
+import { mapImplementationToClientInfo } from "@/runtime/utils/client-info";
 dotenv.config();
 
 class StdioTransport {
@@ -17,6 +22,18 @@ class StdioTransport {
 
   public start(): void {
     try {
+      this.mcpServer.server.oninitialized = () => {
+        const implementation = this.mcpServer.server.getClientVersion();
+        const clientInfo = mapImplementationToClientInfo(implementation);
+        setClientInfoContext({ clientInfo });
+
+        if (this.debug && clientInfo) {
+          console.log(
+            `[STDIO] MCP client initialized: ${clientInfo.name}@${clientInfo.version}`
+          );
+        }
+      };
+
       this.mcpServer.connect(this.transport);
       if (this.debug) {
         console.log("[STDIO] MCP Server running with STDIO transport");
@@ -58,19 +75,35 @@ if (silent) {
   // the MCP stdio protocol on stdout.
   const stderrConsole = new console.Console(process.stderr, process.stderr);
   const methods = [
-    "log", "debug", "info", "warn", "error",
-    "dir", "table", "trace", "assert",
-    "time", "timeEnd", "timeLog",
-    "count", "countReset",
-    "group", "groupEnd", "groupCollapsed",
+    "log",
+    "debug",
+    "info",
+    "warn",
+    "error",
+    "dir",
+    "table",
+    "trace",
+    "assert",
+    "time",
+    "timeEnd",
+    "timeLog",
+    "count",
+    "countReset",
+    "group",
+    "groupEnd",
+    "groupCollapsed",
     "clear",
   ] as const;
   for (const method of methods) {
-    (console as any)[method] = (stderrConsole as any)[method].bind(stderrConsole);
+    (console as any)[method] = (stderrConsole as any)[method].bind(
+      stderrConsole
+    );
   }
 }
 
 createServer().then((mcpServer) => {
   const stdioTransport = new StdioTransport(mcpServer, debug);
-  stdioTransport.start();
+  clientInfoContextProvider({ clientInfo: undefined }, () => {
+    stdioTransport.start();
+  });
 });

--- a/packages/xmcp/src/runtime/utils/__tests__/client-info.test.ts
+++ b/packages/xmcp/src/runtime/utils/__tests__/client-info.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert";
 import {
   extractClientInfoFromMessage,
   extractClientInfoFromMessages,
+  mapImplementationToClientInfo,
 } from "../client-info";
 
 test("extractClientInfoFromMessage returns undefined for non-initialize methods", () => {
@@ -76,5 +77,23 @@ test("extractClientInfoFromMessages supports batch requests", () => {
   assert.deepStrictEqual(result, {
     name: "opencode",
     version: "1.2.3",
+  });
+});
+
+test("mapImplementationToClientInfo maps SDK implementation shape", () => {
+  const result = mapImplementationToClientInfo({
+    name: "claude-code",
+    version: "2.1.0",
+    title: "Claude Code",
+    websiteUrl: "https://claude.ai",
+    description: "CLI coding agent",
+  });
+
+  assert.deepStrictEqual(result, {
+    name: "claude-code",
+    version: "2.1.0",
+    title: "Claude Code",
+    websiteUrl: "https://claude.ai",
+    description: "CLI coding agent",
   });
 });

--- a/packages/xmcp/src/runtime/utils/__tests__/tool-extra.test.ts
+++ b/packages/xmcp/src/runtime/utils/__tests__/tool-extra.test.ts
@@ -5,6 +5,7 @@ import {
   type UserToolResponse,
 } from "../transformers/tool";
 import { httpRequestContextProvider } from "../../contexts/http-request-context";
+import { clientInfoContextProvider } from "../../contexts/client-info-context";
 
 type MinimalExtra = {
   signal: AbortSignal;
@@ -104,6 +105,44 @@ test("transformToolHandler leaves clientInfo undefined when request has no initi
       {
         type: "text",
         text: '{"hasClientInfo":false}',
+      },
+    ],
+  });
+});
+
+test("transformToolHandler uses stdio clientInfo context as fallback", async () => {
+  const transformedHandler = transformToolHandler((_args, extra) => {
+    return {
+      structuredContent: {
+        clientInfoName: extra.clientInfo?.name,
+        clientInfoVersion: extra.clientInfo?.version,
+      },
+    };
+  });
+
+  const result = await new Promise<UserToolResponse>((resolve, reject) => {
+    clientInfoContextProvider(
+      {
+        clientInfo: {
+          name: "opencode",
+          version: "1.2.3",
+        },
+      },
+      () => {
+        invokeHandler(transformedHandler, "rpc-3").then(resolve).catch(reject);
+      }
+    );
+  });
+
+  assert.deepStrictEqual(result, {
+    structuredContent: {
+      clientInfoName: "opencode",
+      clientInfoVersion: "1.2.3",
+    },
+    content: [
+      {
+        type: "text",
+        text: '{"clientInfoName":"opencode","clientInfoVersion":"1.2.3"}',
       },
     ],
   });

--- a/packages/xmcp/src/runtime/utils/client-info.ts
+++ b/packages/xmcp/src/runtime/utils/client-info.ts
@@ -1,5 +1,6 @@
 import type { JsonRpcMessage } from "@/runtime/transports/http/base-streamable-http";
 import type { McpClientInfo } from "@/types/client-info";
+import type { Implementation } from "@modelcontextprotocol/sdk/types";
 
 const isObject = (value: unknown): value is Record<string, unknown> => {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -37,6 +38,12 @@ const parseClientInfoCandidate = (
   }
 
   return result;
+};
+
+export const mapImplementationToClientInfo = (
+  implementation: Implementation | undefined
+): McpClientInfo | undefined => {
+  return parseClientInfoCandidate(implementation);
 };
 
 export const extractClientInfoFromMessage = (

--- a/packages/xmcp/src/runtime/utils/transformers/tool.ts
+++ b/packages/xmcp/src/runtime/utils/transformers/tool.ts
@@ -7,6 +7,7 @@ import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol";
 import { ZodRawShape } from "zod/v3";
 import type { ToolExtraArguments } from "@/types/tool";
 import { getHttpRequestContext } from "@/runtime/contexts/http-request-context";
+import { getClientInfoContext } from "@/runtime/contexts/client-info-context";
 import { elicitFromTool } from "../elicitation";
 import { validateContent } from "../validators";
 
@@ -79,7 +80,15 @@ function createToolExtraArguments(
   try {
     clientInfo = getHttpRequestContext().clientInfo;
   } catch {
-    // no request context available (for example, stdio transport)
+    // no HTTP request context available (for example, stdio transport)
+  }
+
+  if (!clientInfo) {
+    try {
+      clientInfo = getClientInfoContext().clientInfo;
+    } catch {
+      // no client info context available
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

This follows up on #558 and on the HTTP-side work merged in #559.

#559 made `extra.clientInfo` available for HTTP transports. This PR adds the same capability for stdio, so tool handlers can read client identity (`name`, `version`, etc.) regardless of transport.

The stdio path now captures MCP client info from the SDK after `initialize`, stores it in a shared context, and uses that as a fallback when HTTP request context is not present.

## Type of Change

- [ ] Bug fixing
- [x] Adding a feature
- [x] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [x] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [x] Documentation
- [ ] Examples

## Screenshots/Examples

No UI changes.

Behavioral example:

- Before: stdio tool calls always saw `extra.clientInfo` as `undefined`.
- After: once initialization completes, stdio tool calls receive `extra.clientInfo` (same shape as HTTP path).

## Related Issues

- Follow-up to #559
- Closes #558