### PR TITLE
chore: update @xmcp-dev/commet for @commet/node v5.0

### DIFF
--- a/apps/website/content/docs/integrations/commet.mdx
+++ b/apps/website/content/docs/integrations/commet.mdx
@@ -72,15 +72,14 @@ import { commetProvider } from "@xmcp-dev/commet";
 
 export default commetProvider({
   apiKey: process.env.COMMET_API_KEY!,
-  environment: "sandbox",
 });
 ```
 
 ### Configuration Options
 
 - `apiKey`: Your Commet API key (starts with `ck_`)
-- `environment`: Defaults to the SDK's default environment
 - `customerHeader`: HTTP header name for the customer identifier (defaults to `"customer-key"`)
+- `debug`: Enable verbose SDK logging (defaults to `false`)
 
 <Callout variant="info">
   Customer identity is provided via the `customer-key` header (or the established header name you configure in `customerHeader`). This is the same ID you use when creating customers in Commet.
@@ -113,7 +112,7 @@ export default async function exportData({
 }: InferSchema<typeof schema>) {
   const client = getClient();
   const customerId = getCustomerId();
-  const { data } = await client.customer(customerId).features.check("export");
+  const { data } = await client.features.get({ customerId, code: "export" });
 
   if (!data?.allowed) {
     return "Your plan does not include this feature.";
@@ -147,17 +146,16 @@ export default async function aiGenerate({
   const client = getClient();
   const customerId = getCustomerId();
 
-  const { data } = await client.customer(customerId).features.check("ai_generate");
+  const { data } = await client.features.canUse({
+    customerId,
+    code: "ai_generate",
+  });
 
   if (!data?.allowed) {
     return "Your plan does not include this feature.";
   }
 
-  await client.usage.track({
-    feature: "ai_generate",
-    customerId,
-    value: 1,
-  });
+  await client.usage.track({ feature: "ai_generate", customerId, value: 1 });
 
   return `Generated content for: "${prompt}"`;
 }
@@ -187,7 +185,10 @@ export default async function aiChat({
   const client = getClient();
   const customerId = getCustomerId();
 
-  const { data } = await client.customer(customerId).features.check("ai_chat");
+  const { data } = await client.features.canUse({
+    customerId,
+    code: "ai_chat",
+  });
 
   if (!data?.allowed) {
     return "Your plan does not include this feature.";
@@ -221,13 +222,13 @@ export const metadata: ToolMetadata = {
 export default async function manageBilling(): Promise<string> {
   const client = getClient();
   const customerId = getCustomerId();
-  const response = await client.customer(customerId).portal.getUrl();
+  const { success, data } = await client.portal.getUrl({ customerId });
 
-  if (!response.success || !response.data) {
+  if (!success || !data) {
     return "Unable to retrieve billing portal.";
   }
 
-  return `Manage your subscription: ${response.data.portalUrl}`;
+  return `Manage your subscription: ${data.portalUrl}`;
 }
 ```
 

--- a/examples/commet-http/src/middleware.ts
+++ b/examples/commet-http/src/middleware.ts
@@ -2,5 +2,4 @@ import { commetProvider } from "@xmcp-dev/commet";
 
 export default commetProvider({
   apiKey: process.env.COMMET_API_KEY!,
-  environment: "sandbox",
 });

--- a/examples/commet-http/src/tools/ai-tokens-tool.ts
+++ b/examples/commet-http/src/tools/ai-tokens-tool.ts
@@ -11,13 +11,14 @@ export const metadata: ToolMetadata = {
   description: "Chat with AI, tracks token consumption per model",
 };
 
-export default async function aiChat({
-  prompt,
-}: InferSchema<typeof schema>) {
+export default async function aiChat({ prompt }: InferSchema<typeof schema>) {
   const client = getClient();
   const customerId = getCustomerId();
 
-  const { data } = await client.customer(customerId).features.check("ai_chat");
+  const { data } = await client.features.canUse({
+    customerId,
+    code: "ai_chat",
+  });
 
   if (!data?.allowed) {
     return "Your plan does not include this feature.";

--- a/examples/commet-http/src/tools/export-tool.ts
+++ b/examples/commet-http/src/tools/export-tool.ts
@@ -16,7 +16,7 @@ export default async function exportData({
 }: InferSchema<typeof schema>) {
   const client = getClient();
   const customerId = getCustomerId();
-  const { data } = await client.customer(customerId).features.check("export");
+  const { data } = await client.features.get({ customerId, code: "export" });
 
   if (!data?.allowed) {
     return "Your plan does not include this feature.";

--- a/examples/commet-http/src/tools/pro-tool.ts
+++ b/examples/commet-http/src/tools/pro-tool.ts
@@ -17,17 +17,16 @@ export default async function aiGenerate({
   const client = getClient();
   const customerId = getCustomerId();
 
-  const { data } = await client.customer(customerId).features.check("ai_generate");
+  const { data } = await client.features.canUse({
+    customerId,
+    code: "ai_generate",
+  });
 
   if (!data?.allowed) {
     return "Your plan does not include this feature.";
   }
 
-  await client.usage.track({
-    feature: "ai_generate",
-    customerId,
-    value: 1,
-  });
+  await client.usage.track({ feature: "ai_generate", customerId, value: 1 });
 
   return `Generated content for: "${prompt}"`;
 }

--- a/packages/plugins/commet/package.json
+++ b/packages/plugins/commet/package.json
@@ -40,7 +40,7 @@
     "build": "rm -rf dist && tsc"
   },
   "dependencies": {
-    "@commet/node": "^1.9.0",
+    "@commet/node": "^5.0.0",
     "express": "^4.22.1"
   },
   "devDependencies": {

--- a/packages/plugins/commet/src/provider.ts
+++ b/packages/plugins/commet/src/provider.ts
@@ -11,7 +11,7 @@ export function commetProvider(config: CommetProviderConfig): Middleware {
 
   const client = new Commet({
     apiKey: config.apiKey,
-    environment: config.environment,
+    debug: config.debug,
   });
 
   const headerName = config.customerHeader ?? "customer-key";

--- a/packages/plugins/commet/src/types.ts
+++ b/packages/plugins/commet/src/types.ts
@@ -1,5 +1,5 @@
 export interface CommetProviderConfig {
   apiKey: string;
-  environment?: "production" | "sandbox";
   customerHeader?: string;
+  debug?: boolean;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1199,8 +1199,8 @@ importers:
   packages/plugins/commet:
     dependencies:
       '@commet/node':
-        specifier: ^1.9.0
-        version: 1.9.0(typescript@5.9.3)
+        specifier: ^5.0.0
+        version: 5.0.0(typescript@5.9.3)
       express:
         specifier: ^4.22.1
         version: 4.22.1
@@ -1778,8 +1778,8 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@commet/node@1.9.0':
-    resolution: {integrity: sha512-GhbPPCDDliu1ZrIz3YKt1VowKnpMFU8Okta0t+zDARkSIb7xVwOQpuOK22Qh82PMVoJf3ca6iuYPk8YHu1Bjfw==}
+  '@commet/node@5.0.0':
+    resolution: {integrity: sha512-yzeH7y68rGiq/l2T/ntLL4NxesKcwbmSNnDGhamfLclbB728fhHm+1vSIySuTyu6+IhzIWaKlGHKUEeLlZkZSw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       typescript: '>=5.0.0'
@@ -9663,7 +9663,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commet/node@1.9.0(typescript@5.9.3)':
+  '@commet/node@5.0.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
@@ -11732,7 +11732,7 @@ snapshots:
       '@connectrpc/connect-node': 2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))
       axios: 1.16.1
       jose: 5.6.3
-      qs: 6.14.2
+      qs: 6.15.2
     transitivePeerDependencies:
       - debug
       - supports-color


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `canary` branch. PRs to other branches may be closed or require retargeting.**

## Summary

Updates `@xmcp-dev/commet` to the new major version of the underlying SDK, [`@commet/node` v5.0](https://www.npmjs.com/package/@commet/node).

v5.0 is a breaking change: it replaces the scoped `client.customer(id)` accessor with flat resources that take the customer in a params object, and drops the `environment` client option (sandbox vs live now follows the API key). This PR aligns the plugin dependency, the `commet-http` example, and the docs page with the new API.

The plugin's public surface is unchanged — `commetProvider`, `getClient()`, and `getCustomerId()` keep the same shape. The only plugin code change is the provider no longer forwarding the removed `environment` option (it forwards `debug` instead).

### What changed

```diff
  // Feature gating
- await client.customer(customerId).features.check("export");
+ await client.features.get({ customerId, code: "export" });        // boolean
+ await client.features.canUse({ customerId, code: "ai_generate" }); // metered

  // Usage tracking
- await client.customer(customerId).usage.track("ai_generate", 1);
+ await client.usage.track({ feature: "ai_generate", customerId, value: 1 });

  // Billing portal
- await client.customer(customerId).portal.getUrl();
+ await client.portal.getUrl({ customerId });
```

## Type of Change

- [ ] Bug fixing
- [ ] Adding a feature
- [x] Improving documentation
- [x] Adding or updating examples

Also bumps the `@commet/node` dependency in the `@xmcp-dev/commet` plugin from `^1.9.0` to `^5.0.0`.

## Affected Packages

- [ ] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [x] Plugins
- [x] Documentation
- [x] Examples

## Contributor Checklist

- [x] I read `AGENTS.md` and the scoped rules for the areas I touched.
- [x] I kept this PR focused on the stated change.
- [x] I ran the relevant build, lint, test, or example checks.
- [x] I updated docs and a runnable example for user-facing behavior, or explained why an example does not fit.
- [x] I checked `REVIEW_RULES.md` for logging, timers, config shape, wrappers, compiler/loader changes, and stale examples.

## Screenshots/Examples

`pnpm --filter @xmcp-dev/commet build` and the `commet-http` example both build clean against `@commet/node@5.0.0`, and `tsc --noEmit` on the example passes.

The `commet-http` example keeps its 4 tools, now on the v5.0 API:

| Tool | Method | Flow |
|---|---|---|
| `search` | none | Free tool, no gating |
| `export` | `features.get()` | Boolean gate, feature on/off per plan |
| `ai_generate` | `features.canUse()` + `usage.track({ value })` | Metered consumption tracking |
| `ai_chat` | `features.canUse()` + `usage.track({ model, …Tokens })` | AI token tracking per model |

## Related Issues

N/A
