### PR TITLE
Fix canonicals and metadata

### DIFF
--- a/apps/website/app/blog/[...slug]/page.tsx
+++ b/apps/website/app/blog/[...slug]/page.tsx
@@ -98,17 +98,19 @@ export async function generateMetadata(
   if (!meta) notFound();
 
   const { title, description, ogImageUrl } = meta;
+  const canonical = `${SITE_URL}/blog/${slug}`;
 
   return {
     metadataBase: new URL(SITE_URL),
     title,
     description,
     alternates: {
-      canonical: `${SITE_URL}/blog/${slug}`,
+      canonical,
     },
     openGraph: {
       title,
       description,
+      url: canonical,
       siteName: "xmcp",
       type: "article",
       locale: "en_US",

--- a/apps/website/app/blog/page.tsx
+++ b/apps/website/app/blog/page.tsx
@@ -9,10 +9,25 @@ import { BlogCard } from "@/components/home/blog";
 export const dynamic = "force-static";
 
 export const metadata = {
-  title: "Blog - xmcp",
-  description: "Latest updates, guides, and insights about xmcp",
+  title: "xmcp Blog - MCP Guides, Releases, and Engineering Notes",
+  description:
+    "Read xmcp guides, release notes, and engineering articles about building TypeScript MCP servers and production-ready agent tools.",
   alternates: {
     canonical: "https://xmcp.dev/blog",
+  },
+  openGraph: {
+    title: "xmcp Blog - MCP Guides, Releases, and Engineering Notes",
+    description:
+      "Read xmcp guides, release notes, and engineering articles about building TypeScript MCP servers and production-ready agent tools.",
+    url: "https://xmcp.dev/blog",
+    siteName: "xmcp",
+    type: "website",
+    locale: "en_US",
+    images: {
+      url: "/xmcp-og.png",
+      width: 1200,
+      height: 630,
+    },
   },
 };
 

--- a/apps/website/app/docs/[[...slug]]/page.tsx
+++ b/apps/website/app/docs/[[...slug]]/page.tsx
@@ -110,6 +110,7 @@ export async function generateMetadata(
     openGraph: {
       title,
       description,
+      url: canonical,
       siteName: "xmcp",
       type: "article",
       locale: "en_US",

--- a/apps/website/app/showcase/page.tsx
+++ b/apps/website/app/showcase/page.tsx
@@ -10,6 +10,20 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "https://xmcp.dev/showcase",
   },
+  openGraph: {
+    title: "Showcase - xmcp",
+    description:
+      "Join the xmcp showcase program and share your MCP servers with the community.",
+    url: "https://xmcp.dev/showcase",
+    siteName: "xmcp",
+    type: "website",
+    locale: "en_US",
+    images: {
+      url: "/xmcp-og.png",
+      width: 1200,
+      height: 630,
+    },
+  },
 };
 
 export default function ShowcasePage() {

--- a/apps/website/app/telemetry/page.tsx
+++ b/apps/website/app/telemetry/page.tsx
@@ -10,6 +10,20 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "https://xmcp.dev/telemetry",
   },
+  openGraph: {
+    title: "Telemetry - xmcp",
+    description:
+      "Learn what xmcp collects, why the data matters, and how to disable telemetry at any time.",
+    url: "https://xmcp.dev/telemetry",
+    siteName: "xmcp",
+    type: "website",
+    locale: "en_US",
+    images: {
+      url: "/xmcp-og.png",
+      width: 1200,
+      height: 630,
+    },
+  },
 };
 
 export default function TelemetryPage() {

--- a/apps/website/app/templates/[slug]/page.tsx
+++ b/apps/website/app/templates/[slug]/page.tsx
@@ -54,6 +54,10 @@ export async function generateMetadata(
   const canonical = `${baseUrl}/templates/${template.slug}`;
   const metadataName = humanizeMetadataName(template.name);
   const metadataTitle = `${metadataName} | xmcp Templates`;
+  const previewImage = resolveTemplatePreviewImage(template);
+  const previewImageUrl = previewImage.src.startsWith("/")
+    ? `${baseUrl}${previewImage.src}`
+    : previewImage.src;
   const metadataKeywords = Array.from(
     new Set(
       [
@@ -75,21 +79,19 @@ export async function generateMetadata(
       url: canonical,
       siteName: "xmcp",
       type: "website",
-      images: template.previewUrl
-        ? [
-            {
-              url: template.previewUrl,
-              width: 1200,
-              height: 630,
-            },
-          ]
-        : undefined,
+      images: [
+        {
+          url: previewImageUrl,
+          width: 1200,
+          height: 630,
+        },
+      ],
     },
     twitter: {
       card: "summary_large_image",
       title: metadataTitle,
       description: template.description,
-      images: template.previewUrl ? [template.previewUrl] : undefined,
+      images: [previewImageUrl],
     },
   };
 }


### PR DESCRIPTION
## Summary
- Add page-specific Open Graph URLs for docs and blog posts so they match canonicals
- Add Open Graph metadata for /showcase, /blog, and /telemetry
- Always emit template detail OG/Twitter images using existing preview fallback logic

## Verification
- pnpm --filter website lint *(fails before linting files under Node v26.0.0 with ESLint circular config serialization; repo expects Node 20.x)*
- pnpm --filter website build *(compiles, then fails existing typecheck in apps/website/tools/search.ts: cannot find module 'xmcp')*