### PR TITLE
Improve short titles and meta descriptions (XMCP-431)

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -30,7 +30,8 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: "xmcp — The TypeScript MCP framework",
-  description: "The framework for building & shipping MCP applications.",
+  description:
+    "xmcp is the TypeScript framework for building, shipping, and scaling Model Context Protocol servers — tools, prompts, resources, auth, transports, and monetization out of the box.",
   keywords: [
     "xmcp",
     "MCP",
@@ -67,12 +68,14 @@ export const metadata: Metadata = {
     type: "website",
     locale: "en_US",
     title: "xmcp — The TypeScript MCP framework",
-    description: "The framework for building & shipping MCP applications.",
+    description:
+      "xmcp is the TypeScript framework for building, shipping, and scaling Model Context Protocol servers — tools, prompts, resources, auth, transports, and monetization out of the box.",
   },
   twitter: {
     card: "summary_large_image",
     title: "xmcp — The TypeScript MCP framework",
-    description: "The framework for building & shipping MCP applications.",
+    description:
+      "xmcp is the TypeScript framework for building, shipping, and scaling Model Context Protocol servers — tools, prompts, resources, auth, transports, and monetization out of the box.",
     images: {
       url: "/xmcp-og.png",
       width: 1200,

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -11,7 +11,8 @@ export const dynamic = "force-static";
 
 export const metadata: Metadata = {
   title: "xmcp — The TypeScript MCP framework",
-  description: "The framework for building & shipping MCP servers.",
+  description:
+    "xmcp is the TypeScript framework for building, shipping, and scaling Model Context Protocol servers — tools, prompts, resources, auth, transports, and monetization out of the box.",
   alternates: {
     canonical: "https://xmcp.dev",
   },

--- a/apps/website/app/showcase/page.tsx
+++ b/apps/website/app/showcase/page.tsx
@@ -6,14 +6,14 @@ import { Tag } from "@/components/ui/tag";
 export const metadata: Metadata = {
   title: "Showcase - xmcp",
   description:
-    "Join the xmcp showcase program and share your MCP servers with the community.",
+    "Browse production-ready MCP servers built by the xmcp community and submit your own server to be featured in the showcase alongside other developers building AI tooling.",
   alternates: {
     canonical: "https://xmcp.dev/showcase",
   },
   openGraph: {
     title: "Showcase - xmcp",
     description:
-      "Join the xmcp showcase program and share your MCP servers with the community.",
+      "Browse production-ready MCP servers built by the xmcp community and submit your own server to be featured in the showcase alongside other developers building AI tooling.",
     url: "https://xmcp.dev/showcase",
     siteName: "xmcp",
     type: "website",

--- a/apps/website/app/telemetry/page.tsx
+++ b/apps/website/app/telemetry/page.tsx
@@ -6,14 +6,14 @@ export const dynamic = "force-static";
 export const metadata: Metadata = {
   title: "Telemetry - xmcp",
   description:
-    "Learn what xmcp collects, why the data matters, and how to disable telemetry at any time.",
+    "xmcp collects anonymous build and run telemetry to prioritize transport, adapter, and compiler fixes. Learn exactly what we collect, why it matters, and how to opt out at any time.",
   alternates: {
     canonical: "https://xmcp.dev/telemetry",
   },
   openGraph: {
     title: "Telemetry - xmcp",
     description:
-      "Learn what xmcp collects, why the data matters, and how to disable telemetry at any time.",
+      "xmcp collects anonymous build and run telemetry to prioritize transport, adapter, and compiler fixes. Learn exactly what we collect, why it matters, and how to opt out at any time.",
     url: "https://xmcp.dev/telemetry",
     siteName: "xmcp",
     type: "website",

--- a/apps/website/app/templates/category/[slug]/page.tsx
+++ b/apps/website/app/templates/category/[slug]/page.tsx
@@ -46,7 +46,7 @@ export async function generateMetadata(
 
   const label = humanizeMetadataName(match);
   const title = `${label} templates - xmcp`;
-  const description = `xmcp templates in the ${label} category — real-world implementations and best practices.`;
+  const description = `Browse ${label} templates built with xmcp — production-ready MCP servers showcasing authentication, transports, monetization, and integrations you can fork and deploy.`;
   const canonical = `${baseUrl}/templates/category/${params.slug}`;
 
   return {

--- a/apps/website/content/blog/apps-monetization.mdx
+++ b/apps/website/content/blog/apps-monetization.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Monetize your GPT apps with Stripe"
-description: "Learn how to monetize your GPT apps using Stripe external checkout integration."
-summary: "Learn how to monetize your GPT apps using Stripe external checkout integration."
+description: "Learn how to monetize your GPT apps with Stripe external checkout — set up paywalls, handle payments server-side, and gate tools behind successful charges."
+summary: "Learn how to monetize your GPT apps with Stripe external checkout — set up paywalls, handle payments server-side, and gate tools behind successful charges."
 category: "guide"
 date: "2025-12-16"
 order: 2

--- a/apps/website/content/blog/apps-sdk.mdx
+++ b/apps/website/content/blog/apps-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenAI Apps SDK Support"
-description: "xmcp now supports building compatible UI resources and tools with the OpenAI Apps SDK, out of the box."
+description: "xmcp now supports building UI resources and tools compatible with the OpenAI Apps SDK out of the box — ship ChatGPT apps without custom rendering code."
 category: "changelog"
 date: "2025-10-11"
 order: 1

--- a/apps/website/content/blog/better-auth-integration.mdx
+++ b/apps/website/content/blog/better-auth-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrating Better Auth with xmcp"
-description: "Learn how to add secure authentication to your xmcp app using Better Auth and PostgreSQL"
+description: "Learn how to add secure authentication to your xmcp MCP server using Better Auth with PostgreSQL — sessions, account linking, and OAuth 2.1 providers."
 category: "guides"
 date: "2025-08-13"
 order: 5

--- a/apps/website/content/blog/build-and-submit-gpt-apps.mdx
+++ b/apps/website/content/blog/build-and-submit-gpt-apps.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to submit your GPT app"
-description: "A complete guide to submitting your ChatGPT App to the OpenAI directory"
+description: "A complete guide to submitting your ChatGPT App to the OpenAI directory — prepare your GPT, complete review requirements, and ship to production."
 category: "guides"
 date: "2025-12-23"
 order: 5

--- a/apps/website/content/blog/cli-typed-clients.mdx
+++ b/apps/website/content/blog/cli-typed-clients.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Connect to external MCPs and make their tools yours"
-description: "Generate fully typed MCPs clients from remote servers or STDIO packages with one command."
+description: "Generate fully typed TypeScript MCP clients from remote HTTP servers or STDIO packages with one xmcp command, with autocomplete for tools and prompts."
 category: "guides"
 date: "2025-12-11"
 order: 7

--- a/apps/website/content/blog/doom-with-xmcp.mdx
+++ b/apps/website/content/blog/doom-with-xmcp.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Running DOOM in ChatGPT: A Step-by-Step Guide"
-description: "Learn how we made DOOM playable in ChatGPT thanks to xmcp"
+description: "Learn how we made DOOM playable inside ChatGPT using xmcp — rendering frames as images, streaming inputs, and shipping an MCP-powered game loop."
 category: "guides"
 date: "2025-12-12"
 order: 6
-summary: "Learn how we made DOOM playable in ChatGPT using xmcp"
+summary: "Learn how we made DOOM playable inside ChatGPT using xmcp — rendering frames as images, streaming inputs, and shipping an MCP-powered game loop."
 textureImage: "/textures/text3.png"
 authors:
   - 0xkoller

--- a/apps/website/content/blog/everything-we-shipped-so-far.mdx
+++ b/apps/website/content/blog/everything-we-shipped-so-far.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Everything we shipped so far"
-description: "From GPT apps to React components, external MCP clients, and monetization."
+description: "From GPT apps and React components to external MCP clients, OAuth, and monetization — a recap of everything we shipped across xmcp this year."
 category: "changelog"
 date: "2025-12-20"
 order: 8

--- a/apps/website/content/blog/mcp-apps.mdx
+++ b/apps/website/content/blog/mcp-apps.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to build an MCP App"
-description: "Learn how to build an MCP app using xmcp out-of-the-box support."
+description: "Learn how to build an MCP App with xmcp — ship interactive React widgets, tool-rendered UIs, and ChatGPT-compatible resources with out-of-the-box support."
 category: "guides"
 date: "2026-01-26"
 order: 1

--- a/apps/website/content/blog/paying-for-mcp-tools-with-x402.mdx
+++ b/apps/website/content/blog/paying-for-mcp-tools-with-x402.mdx
@@ -1,7 +1,7 @@
 ---
 title: "When your agent has to pay"
-description: "Charging for a tool is the easy half. The real shift is software that pays for tools on its own."
-summary: "Charging for a tool is the easy half. The real shift is software that pays for tools on its own."
+description: "Charging for a tool is the easy half. The real shift is software that pays for tools on its own — how x402 lets agents settle USDC micropayments per call."
+summary: "Charging for a tool is the easy half. The real shift is software that pays for tools on its own — how x402 lets agents settle USDC micropayments per call."
 category: "engineering"
 date: "2026-05-27"
 featured: false

--- a/apps/website/content/blog/polar-integration.mdx
+++ b/apps/website/content/blog/polar-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrating Polar with xmcp"
-description: "Learn how to add paywalls and track tool usage with Polar."
+description: "Learn how to add paywalls and track per-tool usage with Polar license keys in xmcp — gating tools, subscriptions, and metered billing for MCP servers."
 category: "guides"
 date: "2025-09-26"
 order: 2

--- a/apps/website/content/blog/react-client-components.mdx
+++ b/apps/website/content/blog/react-client-components.mdx
@@ -1,7 +1,7 @@
 ---
 title: "When tools need UIs"
-description: "Our philosophy on bringing UI components to MCP tools."
-summary: "Our philosophy on bringing UI components to MCP tools."
+description: "Our philosophy on bringing UI components to MCP tools — when tools need interfaces, how React widgets render inside ChatGPT, and what we chose to ship."
+summary: "Our philosophy on bringing UI components to MCP tools — when tools need interfaces, how React widgets render inside ChatGPT, and what we chose to ship."
 category: "engineering"
 date: "2026-01-06"
 order: 2

--- a/apps/website/content/blog/v0.3.0-release.mdx
+++ b/apps/website/content/blog/v0.3.0-release.mdx
@@ -1,6 +1,6 @@
 ---
-title: "xmcp v0.3.0"
-description: "xmcp v0.3.0 covers all MCP server features - tools, prompts, and resources. Available now."
+title: "xmcp v0.3.0 — Tools, Prompts, and Resources"
+description: "xmcp v0.3.0 ships full MCP server coverage — tools, prompts, and resources — plus auth, transports, and adapter improvements. Available now."
 category: "changelog"
 date: "2025-09-19"
 order: 3

--- a/apps/website/content/blog/vercel-zero-config.mdx
+++ b/apps/website/content/blog/vercel-zero-config.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deploy to Vercel with zero-configuration"
-description: "Kick off your project instantly with the template."
+description: "Kick off your xmcp project instantly with the Vercel template — zero-configuration deploys, instant previews on every push, and serverless MCP hosting."
 category: "changelog"
 date: "2025-08-23"
 order: 4

--- a/apps/website/content/blog/x402-integration.mdx
+++ b/apps/website/content/blog/x402-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Pay-per-use MCP tools with x402"
-description: "Charge per tool call using crypto micropayments"
-summary: "Charge per tool call using crypto micropayments"
+description: "Charge per tool call using x402 crypto micropayments with USDC on Base — gate your MCP tools behind HTTP 402 payment-required middleware."
+summary: "Charge per tool call using x402 crypto micropayments with USDC on Base — gate your MCP tools behind HTTP 402 payment-required middleware."
 category: "engineering"
 date: "2026-01-27"
 order: 2

--- a/apps/website/content/docs/adapters/express.mdx
+++ b/apps/website/content/docs/adapters/express.mdx
@@ -2,7 +2,7 @@
 title: "Express"
 metadataTitle: "Usage with Express | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to integrate xmcp with your existing Express application."
+summary: "Integrate xmcp into your existing Express application — mount the MCP server on a route, reuse middleware, and ship tools and prompts."
 description: "Plug xmcp into your existing Express application."
 ---
 

--- a/apps/website/content/docs/adapters/fastify.mdx
+++ b/apps/website/content/docs/adapters/fastify.mdx
@@ -2,7 +2,7 @@
 title: "Fastify"
 metadataTitle: "Usage with Fastify | xmcp Documentation"
 publishedAt: "2026-04-16"
-summary: "Learn how to use xmcp with Fastify to build and deploy MCP servers."
+summary: "Run an xmcp MCP server on Fastify with one adapter call — works on any Node.js deployment including serverless and AWS Lambda targets."
 description: "Run an xmcp MCP server on Fastify. Works on any Node.js deployment target including AWS Lambda."
 ---
 

--- a/apps/website/content/docs/adapters/nestjs.mdx
+++ b/apps/website/content/docs/adapters/nestjs.mdx
@@ -2,7 +2,7 @@
 title: "NestJS"
 metadataTitle: "Usage with NestJS | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to integrate xmcp with your existing NestJS application."
+summary: "Integrate xmcp into your existing NestJS application with automatic tool discovery, module-based configuration, and full MCP server support."
 description: "Plug xmcp into your existing NestJS application with automatic tool discovery and customizable module configuration."
 ---
 

--- a/apps/website/content/docs/adapters/nextjs.mdx
+++ b/apps/website/content/docs/adapters/nextjs.mdx
@@ -2,7 +2,7 @@
 title: "Next.js"
 metadataTitle: "Usage with Next.js | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to integrate xmcp with your existing Next.js application."
+summary: "Integrate xmcp into your existing Next.js application — add an MCP route handler, reuse server actions, and ship tools from your app router."
 description: "Plug xmcp into your existing Next.js application."
 ---
 

--- a/apps/website/content/docs/authentication/api-key.mdx
+++ b/apps/website/content/docs/authentication/api-key.mdx
@@ -2,7 +2,7 @@
 title: "API Key"
 metadataTitle: "API Key Authentication | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to use API key authentication in your xmcp application."
+summary: "Secure your xmcp MCP server with API key authentication — issue keys, validate incoming requests, and gate tools, prompts, and resources."
 description: "Secure access and protect your MCP server using API keys."
 ---
 

--- a/apps/website/content/docs/authentication/jwt.mdx
+++ b/apps/website/content/docs/authentication/jwt.mdx
@@ -2,7 +2,7 @@
 title: "JSON Web Token"
 metadataTitle: "JWT Authentication | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to use JWT authentication in your xmcp application."
+summary: "Add JWT authentication to your xmcp MCP server — generate and verify JSON Web Tokens, define scopes, and protect tools and prompts."
 description: "Secure access and protect your MCP server using JSON Web Tokens."
 ---
 

--- a/apps/website/content/docs/authentication/oauth.mdx
+++ b/apps/website/content/docs/authentication/oauth.mdx
@@ -2,7 +2,7 @@
 title: "OAuth"
 metadataTitle: "OAuth Authentication | xmcp Documentation"
 publishedAt: "2025-01-16"
-summary: "OAuth authentication plugins for xmcp servers."
+summary: "Add OAuth 2.1 authentication to your xmcp MCP server with production-ready plugins, PKCE flows, scopes, and provider integrations."
 description: "Production-ready OAuth implementations with authentication plugins."
 ---
 

--- a/apps/website/content/docs/configuration/bundler.mdx
+++ b/apps/website/content/docs/configuration/bundler.mdx
@@ -2,7 +2,7 @@
 title: "Bundler"
 metadataTitle: "Custom Bundler Configuration | xmcp Documentation"
 publishedAt: "2025-11-20"
-summary: "Learn how to customize the bundler configuration."
+summary: "Customize the xmcp bundler configuration to extend your MCP server build with custom aliases, externals, and runtime targets."
 description: "Extend the bundler configuration for your MCP server."
 ---
 

--- a/apps/website/content/docs/configuration/custom-directories.mdx
+++ b/apps/website/content/docs/configuration/custom-directories.mdx
@@ -2,7 +2,7 @@
 title: "Custom Directories"
 metadataTitle: "Custom Directories | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to customize the directories for tools, prompts, and resources."
+summary: "Customize where xmcp looks for tools, prompts, and resources — relocate the default directories or add multiple source paths for your MCP server."
 description: "Customize where xmcp looks for tools, prompts, and resources."
 ---
 

--- a/apps/website/content/docs/configuration/server-info.mdx
+++ b/apps/website/content/docs/configuration/server-info.mdx
@@ -2,7 +2,7 @@
 title: "Server Info"
 metadataTitle: "Server Info Configuration | xmcp Documentation"
 publishedAt: "2026-03-10"
-summary: "Configure your MCP server identity, instructions, icons, and home page."
+summary: "Configure your xmcp MCP server identity — name, description, instructions, icons, and home page — so clients and users see the right metadata."
 description: "Customize the name, description, instructions, icons, and home page of your MCP server."
 ---
 

--- a/apps/website/content/docs/configuration/telemetry.mdx
+++ b/apps/website/content/docs/configuration/telemetry.mdx
@@ -2,7 +2,7 @@
 title: "Telemetry"
 metadataTitle: "Telemetry Controls | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Understand what xmcp collects and the fastest ways to turn telemetry off."
+summary: "Understand what xmcp telemetry collects — anonymous build and run signals — and the fastest ways to disable it per command or persistently."
 description: "A condensed version of the telemetry policy with actionable opt-out instructions."
 ---
 

--- a/apps/website/content/docs/configuration/transports.mdx
+++ b/apps/website/content/docs/configuration/transports.mdx
@@ -2,7 +2,7 @@
 title: "Transports"
 metadataTitle: "Transports | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to customize the transports configuration."
+summary: "Configure the transports for your xmcp MCP server, switching between HTTP and STDIO and tuning streamable HTTP and stdio options."
 description: "Customize the transport types for your MCP server."
 ---
 

--- a/apps/website/content/docs/core-concepts/css.mdx
+++ b/apps/website/content/docs/core-concepts/css.mdx
@@ -1,6 +1,6 @@
 ---
 title: CSS
-description: Style your xmcp tools with Tailwind CSS, CSS, or CSS Modules
+description: Style your xmcp MCP tools with Tailwind CSS, CSS Modules, or plain CSS, including class management and theming for tool-rendered UI components.
 ---
 
 If you're using [MCP Apps](/docs/core-concepts/tools#mcp-apps-metadata), xmcp provides your application multiple ways to use CSS:

--- a/apps/website/content/docs/core-concepts/external-clients.mdx
+++ b/apps/website/content/docs/core-concepts/external-clients.mdx
@@ -2,7 +2,7 @@
 title: "External Clients"
 metadataTitle: "External Clients | xmcp Documentation"
 publishedAt: "2025-12-19"
-summary: "Connect to external MCP servers and generate typed clients."
+summary: "Connect to external MCP servers over HTTP or STDIO and generate fully typed TypeScript clients with autocomplete for tools, prompts, and resources."
 description: "Learn how to connect to external MCP servers via HTTP or STDIO and generate fully typed TypeScript clients with autocomplete support."
 ---
 

--- a/apps/website/content/docs/core-concepts/middlewares.mdx
+++ b/apps/website/content/docs/core-concepts/middlewares.mdx
@@ -2,7 +2,7 @@
 title: "Middlewares"
 metadataTitle: "Middlewares | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to use middlewares for request/response processing."
+summary: "Use middlewares in your xmcp MCP server to intercept, transform, and gate incoming requests and outgoing responses across tools, prompts, and resources."
 descriptions: "Useful for intercepting and processing requests and responses."
 ---
 

--- a/apps/website/content/docs/core-concepts/prompts.mdx
+++ b/apps/website/content/docs/core-concepts/prompts.mdx
@@ -2,7 +2,7 @@
 title: "Prompts"
 metadataTitle: "Prompts | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to create and use prompts in your xmcp application."
+summary: "Create and register prompts in your xmcp MCP server — parameterized instruction templates that give users structured, reusable LLM workflows."
 description: "Prompts are user-controlled instruction templates that enable structured, consistent interactions through parameterized workflows."
 ---
 

--- a/apps/website/content/docs/core-concepts/resources.mdx
+++ b/apps/website/content/docs/core-concepts/resources.mdx
@@ -2,7 +2,7 @@
 title: "Resources"
 metadataTitle: "Resources | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to create and use resources in your xmcp application."
+summary: "Create and expose resources in your xmcp MCP server — read-only data sources from files, APIs, and databases that give your LLM contextual information."
 description: "Resources are application-driven, read-only data sources that provide context to AI models from files, APIs, databases, and other sources."
 ---
 

--- a/apps/website/content/docs/core-concepts/tools.mdx
+++ b/apps/website/content/docs/core-concepts/tools.mdx
@@ -2,7 +2,7 @@
 title: "Tools"
 metadataTitle: "Tools | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to create and use tools in your xmcp application."
+summary: "Create and register tools in your xmcp MCP server — typed functions your LLM can call to interact with APIs, databases, files, and other systems."
 description: "Tools are functions that your LLM can actively call and decides when to use based on user requests. They enable AI models to perform actions such as writing to databases, calling external APIs, modifying files, or triggering other logic."
 ---
 

--- a/apps/website/content/docs/deployment/alpic.mdx
+++ b/apps/website/content/docs/deployment/alpic.mdx
@@ -2,7 +2,7 @@
 title: "Alpic"
 metadataTitle: "Alpic Deployment | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to deploy your xmcp application to Alpic."
+summary: "Deploy your xmcp MCP server to Alpic, the MCP-first cloud platform, with one-click zero-configuration deployment and managed hosting."
 description: "Alpic is a MCP-first cloud platform with one-click deployment for xmcp servers. Deploy your xmcp server to Alpic with zero-configuration."
 ---
 

--- a/apps/website/content/docs/deployment/cloudflare.mdx
+++ b/apps/website/content/docs/deployment/cloudflare.mdx
@@ -2,7 +2,7 @@
 title: "Cloudflare"
 metadataTitle: "Cloudflare Deployment | xmcp Documentation"
 publishedAt: "2026-02-04"
-summary: "Learn how to deploy your xmcp application to Cloudflare Workers."
+summary: "Deploy your xmcp MCP server to Cloudflare Workers with the Cloudflare-native bundle, Wrangler for local dev, and global edge runtime hosting."
 description: "Cloudflare Workers support in xmcp uses a Cloudflare-native bundle and Wrangler for local dev and deploy."
 ---
 

--- a/apps/website/content/docs/deployment/replit.mdx
+++ b/apps/website/content/docs/deployment/replit.mdx
@@ -2,7 +2,7 @@
 title: "Replit"
 metadataTitle: "Replit Deployment | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to deploy your xmcp application to Replit."
+summary: "Deploy your xmcp MCP server to Replit with one-click setup, live editing, and managed hosting from your browser in minutes."
 description: "Deploy your xmcp application to Replit with a single click."
 ---
 

--- a/apps/website/content/docs/deployment/vercel.mdx
+++ b/apps/website/content/docs/deployment/vercel.mdx
@@ -2,7 +2,7 @@
 title: "Vercel"
 metadataTitle: "Vercel Deployment | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to deploy your xmcp application to Vercel."
+summary: "Deploy your xmcp MCP server to Vercel with zero-configuration, instant previews on every push, and edge-native serverless hosting."
 description: "Vercel supports xmcp with zero-configuration."
 ---
 

--- a/apps/website/content/docs/discoverability/smithery.mdx
+++ b/apps/website/content/docs/discoverability/smithery.mdx
@@ -2,7 +2,7 @@
 title: "Smithery"
 metadataTitle: "Publish to Smithery | xmcp Documentation"
 publishedAt: "2026-03-13"
-summary: "Publish your xmcp server to Smithery for distribution and observability."
+summary: "Publish your xmcp MCP server to Smithery for distribution, discovery, and runtime observability — reach more users through the Smithery registry."
 description: "Publish your xmcp server to Smithery for distribution and observability."
 ---
 

--- a/apps/website/content/docs/getting-started/connecting.mdx
+++ b/apps/website/content/docs/getting-started/connecting.mdx
@@ -2,7 +2,7 @@
 title: "Connecting to your server"
 metadataTitle: "Connecting to your server | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to configure MCP clients to connect to your xmcp server."
+summary: "Connect MCP clients to your xmcp server over HTTP or STDIO — configure local development clients and production transport for remote agents."
 description: "Configure HTTP and STDIO transport connections for local development and production environments"
 ---
 

--- a/apps/website/content/docs/getting-started/installation.mdx
+++ b/apps/website/content/docs/getting-started/installation.mdx
@@ -2,7 +2,7 @@
 title: "Installation"
 metadataTitle: "Installation | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Learn how to install xmcp."
+summary: "Install xmcp via the CLI scaffold or manually, set up your TypeScript MCP server, and configure build and dev scripts in a few minutes."
 description: "Set up your MCP server using automated scaffolding or manual installation, configure build scripts, and troubleshoot transport configurations"
 ---
 

--- a/apps/website/content/docs/getting-started/project-structure.mdx
+++ b/apps/website/content/docs/getting-started/project-structure.mdx
@@ -2,7 +2,7 @@
 title: "Project structure"
 metadataTitle: "Project structure | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Understand the basic project layout and organization."
+summary: "Explore the xmcp project layout — file-system based auto-discovery for tools, prompts, and resources, plus config options for custom directory layouts."
 description: "Explore the file-system based architecture with auto-discovery for tools, prompts, and resources, plus configuration options for custom directory layouts"
 ---
 

--- a/apps/website/content/docs/guides/authentication.mdx
+++ b/apps/website/content/docs/guides/authentication.mdx
@@ -2,7 +2,7 @@
 title: "Authentication"
 metadataTitle: "MCP Server Authentication Guide | xmcp Documentation"
 publishedAt: "2026-01-19"
-summary: "Learn how authentication works on MCP servers with human-based interaction."
+summary: "Secure your xmcp MCP server with OAuth 2.1, API keys, or JWT — understand authentication vs authorization, PKCE, scopes, and provider integrations."
 description: "Secure your MCP server with OAuth 2.1, API keys, or JWT tokens. Understand authentication vs authorization, PKCE, scopes, and token-based access control. Integrate with Better Auth, Clerk, Auth0, or WorkOS."
 ---
 

--- a/apps/website/content/docs/guides/monetization.mdx
+++ b/apps/website/content/docs/guides/monetization.mdx
@@ -2,7 +2,7 @@
 title: "Monetization"
 metadataTitle: "MCP Server Monetization Guide | xmcp Documentation"
 publishedAt: "2026-01-19"
-summary: "Learn how monetization works on xmcp servers with payment-based access control."
+summary: "Charge for your xmcp MCP tools with license-key gating or crypto micropayments — understand human vs agent models and integrate Polar or x402."
 description: "Charge for your MCP tools using license keys or crypto micropayments. Understand human vs agent monetization models, and integrate with Polar or x402."
 ---
 

--- a/apps/website/content/docs/guides/xmcp-mcp-server.mdx
+++ b/apps/website/content/docs/guides/xmcp-mcp-server.mdx
@@ -2,7 +2,7 @@
 title: "xmcp MCP server"
 metadataTitle: "xmcp Documentation MCP Server for Coding Agents | xmcp Documentation"
 publishedAt: "2025-12-27"
-summary: "Enable AI coding agents to access xmcp documentation through MCP."
+summary: "Connect AI coding agents to the xmcp documentation MCP server for real-time answers about features, configuration, and best practices."
 description: "Connect coding agents to xmcp's documentation MCP server to get real-time answers about xmcp features, configuration, and best practices."
 displayTitle: "xmcp MCP server setup guide for agents" 
 ---

--- a/apps/website/content/docs/index.mdx
+++ b/apps/website/content/docs/index.mdx
@@ -2,7 +2,7 @@
 title: "Introduction"
 metadataTitle: "xmcp - Getting Started | Documentation"
 publishedAt: "2025-07-06"
-summary: "The framework for building & shipping MCP servers."
+summary: "Get started with xmcp, the TypeScript framework for building and shipping Model Context Protocol servers with tools, prompts, and resources."
 description: "xmcp is a framework for building and shipping MCP servers with TypeScript. Designed with DX in mind, it simplifies setup and removes friction in just one command — making it easy to build & deploy AI tools on top of the Model Context Protocol ecosystem."
 ---
 

--- a/apps/website/content/docs/integrations/auth0.mdx
+++ b/apps/website/content/docs/integrations/auth0.mdx
@@ -2,7 +2,7 @@
 title: "Auth0"
 metadataTitle: "Usage with Auth0 | xmcp Documentation"
 publishedAt: "2026-01-16"
-summary: "Add secure authentication to your MCP server using Auth0"
+summary: "Add secure OAuth 2.1 authentication to your xmcp MCP server using the Auth0 plugin, with scope-based authorization and provider integrations."
 description: "The Auth0 plugin provides authentication for your MCP server using Auth0 with scope-based authorization."
 ---
 

--- a/apps/website/content/docs/integrations/better-auth.mdx
+++ b/apps/website/content/docs/integrations/better-auth.mdx
@@ -2,7 +2,7 @@
 title: "Better Auth"
 metadataTitle: "Usage with Better Auth | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Add secure authentication to your MCP server using Better Auth and PostgreSQL"
+summary: "Add secure authentication to your xmcp MCP server using Better Auth and PostgreSQL — sessions, account linking, and OAuth 2.1 provider flows."
 description: "Add secure authentication to your MCP server using Better Auth and PostgreSQL"
 ---
 

--- a/apps/website/content/docs/integrations/clerk.mdx
+++ b/apps/website/content/docs/integrations/clerk.mdx
@@ -2,7 +2,7 @@
 title: "Clerk"
 metadataTitle: "Usage with Clerk | xmcp Documentation"
 publishedAt: "2026-01-14"
-summary: "Add secure authentication to your MCP server using Clerk"
+summary: "Add secure OAuth 2.1 authentication to your xmcp MCP server using the Clerk plugin, with session management and organization support."
 description: "The Clerk plugin provides authentication for your MCP server using Clerk's OAuth system."
 ---
 

--- a/apps/website/content/docs/integrations/commet.mdx
+++ b/apps/website/content/docs/integrations/commet.mdx
@@ -2,7 +2,7 @@
 title: "Commet"
 metadataTitle: "Usage with Commet | xmcp Documentation"
 publishedAt: "2026-04-02"
-summary: "Add subscription-aware billing, feature gating, and usage tracking to your xmcp server with Commet"
+summary: "Add subscription-aware billing, feature gating, and per-tool usage tracking to your xmcp MCP server with the Commet integration for plan-tiered access."
 description: "Add subscription-aware billing, feature gating, and usage tracking to your xmcp server with Commet"
 ---
 

--- a/apps/website/content/docs/integrations/polar.mdx
+++ b/apps/website/content/docs/integrations/polar.mdx
@@ -2,7 +2,7 @@
 title: "Polar"
 metadataTitle: "Usage with Polar | xmcp Documentation"
 publishedAt: "2025-07-06"
-summary: "Add paywalls and track tool usage with license keys using Polar"
+summary: "Add paywalls and license-key gating to your xmcp MCP tools with the Polar integration, including subscription tiers and per-tool usage tracking."
 description: "Add paywalls and track tool usage with license keys using Polar"
 ---
 

--- a/apps/website/content/docs/integrations/scalekit.mdx
+++ b/apps/website/content/docs/integrations/scalekit.mdx
@@ -2,7 +2,7 @@
 title: "Scalekit"
 metadataTitle: "Usage with Scalekit | xmcp Documentation"
 publishedAt: "2026-06-28"
-summary: "Add secure authentication to your MCP server using Scalekit"
+summary: "Add secure OAuth 2.1 authentication to your xmcp MCP server using the Scalekit plugin, with multi-tenant authorization and team isolation."
 description: "The Scalekit plugin provides OAuth 2.1 authentication for your MCP server using Scalekit as the authorization server."
 ---
 

--- a/apps/website/content/docs/integrations/workos.mdx
+++ b/apps/website/content/docs/integrations/workos.mdx
@@ -2,7 +2,7 @@
 title: "WorkOS"
 metadataTitle: "Usage with WorkOS | xmcp Documentation"
 publishedAt: "2026-01-12"
-summary: "Add secure authentication to your MCP server using WorkOS AuthKit"
+summary: "Add secure OAuth 2.1 authentication to your xmcp MCP server using the WorkOS AuthKit plugin, with managed sessions and user directories."
 description: "The WorkOS plugin provides authentication for your mcp server using WorkOS AuthKit."
 ---
 

--- a/apps/website/content/docs/integrations/x402.mdx
+++ b/apps/website/content/docs/integrations/x402.mdx
@@ -2,7 +2,7 @@
 title: "x402"
 metadataTitle: "Usage with x402 | xmcp Documentation"
 publishedAt: "2026-01-19"
-summary: "Monetize your MCP tools with USDC payments on Base"
+summary: "Monetize your MCP tools using the x402 HTTP payment protocol with USDC micropayments on Base, gated behind pay-per-call middleware."
 description: "The x402 plugin enables tool monetization through the HTTP 402 payment protocol using USDC on Base."
 ---
 


### PR DESCRIPTION
Expand short meta descriptions and titles on the website so indexable pages no longer trip Warning-indexable-Meta_description_too_short and Warning-indexable-Title_too_short crawl warnings.

Page-level metadata:
- Homepage (/) and root layout: expand description from 50 to ~175 chars
- /showcase: 77 -> ~170 chars
- /telemetry: 89 -> ~180 chars
- /templates/category/[slug]: per-category description 82-94 -> ~155 chars

Docs (38 MDX frontmatter): expand the short 'summary' field (which generateMetadata prefers over 'description' via summary ?? description) from 26-98 chars to 120-155 chars for every docs page.

Blog (13 MDX frontmatter): expand short descriptions to >=120 chars and lengthen the cryptic 'xmcp v0.3.0' title to 'xmcp v0.3.0 - Tools, Prompts, and Resources'.

Redirect chain for xmcp.dev variants (Notice-Redirect_chain.csv): http://www.xmcp.dev/  ->308->  https://www.xmcp.dev/  ->307->  https://xmcp.dev/ This is a Vercel project-domain setting (Vercel intercepts 'www' before Next middleware), not an app-route or vercel.json issue. No app-code fix shipped in this branch; the fix belongs in the Vercel dashboard: remove www.xmcp.dev as a production domain or point its redirect directly at https://xmcp.dev.

Verified: pnpm --filter website build passes (TypeScript + prerender). Note: 'pnpm --filter website lint' currently fails with a pre-existing ESLint/eslintrc circular-structure error that also reproduces on canary, so it is unrelated to these changes.