### PR TITLE
feat(website): markdown content negotiation for agents

### DIFF
--- a/apps/website/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/website/app/llms.mdx/[[...slug]]/route.ts
@@ -1,4 +1,5 @@
 import { getLLMText } from "../../../lib/get-llm-text";
+import { estimateTokens } from "../../../lib/estimate-tokens";
 import { source } from "../../../lib/source";
 import { notFound } from "next/navigation";
 
@@ -12,9 +13,15 @@ export async function GET(
   const page = source.getPage(slug);
   if (!page) notFound();
 
-  return new Response(await getLLMText(page), {
+  const text = await getLLMText(page);
+
+  return new Response(text, {
     headers: {
-      "Content-Type": "text/markdown",
+      "Content-Type": "text/markdown; charset=utf-8",
+      // This route is the markdown half of Accept-based content negotiation,
+      // so caches must key on Accept to avoid mixing it with the HTML page.
+      Vary: "Accept",
+      "x-markdown-tokens": String(estimateTokens(text)),
     },
   });
 }

--- a/apps/website/lib/estimate-tokens.ts
+++ b/apps/website/lib/estimate-tokens.ts
@@ -1,0 +1,7 @@
+// Rough token estimate (~4 chars/token); good enough for the x-markdown-tokens
+// hint that lets agents gauge context-window cost before fetching.
+const CHARS_PER_TOKEN = 4;
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -60,12 +60,29 @@ const nextConfig: NextConfig = {
     ];
   },
   async rewrites() {
-    return [
-      { source: "/docs/:slug*.md", destination: "/llms.mdx/:slug*" },
-      { source: "/docs/:slug*.mdx", destination: "/llms.mdx/:slug*" },
-      { source: "/docs.md", destination: "/llms.txt" },
-      { source: "/docs.mdx", destination: "/llms.txt" },
+    // Content negotiation: agents sending `Accept: text/markdown` get the
+    // markdown route; browsers (which never list text/markdown) fall through to
+    // HTML. These must run in `beforeFiles` so `/` is intercepted before the
+    // homepage page route resolves (`afterFiles` runs after page matching).
+    const acceptsMarkdown = [
+      { type: "header" as const, key: "accept", value: ".*text/markdown.*" },
     ];
+    return {
+      beforeFiles: [
+        { source: "/", has: acceptsMarkdown, destination: "/llms.mdx" },
+        {
+          source: "/docs/:slug*",
+          has: acceptsMarkdown,
+          destination: "/llms.mdx/:slug*",
+        },
+      ],
+      afterFiles: [
+        { source: "/docs/:slug*.md", destination: "/llms.mdx/:slug*" },
+        { source: "/docs/:slug*.mdx", destination: "/llms.mdx/:slug*" },
+        { source: "/docs.md", destination: "/llms.txt" },
+        { source: "/docs.mdx", destination: "/llms.txt" },
+      ],
+    };
   },
   async headers() {
     // RFC 8288 Link headers point agents at discoverable resources from the


### PR DESCRIPTION
## What

Enable **Markdown for Agents** on the website: requests sending `Accept: text/markdown` now receive a markdown version of the page, while browsers keep getting HTML by default. Continues the agent-discoverability work from #603 (RFC 8288 Link headers).

The site runs on Vercel (not Cloudflare), so Cloudflare's automatic edge feature doesn't apply — this implements the same HTTP content-negotiation contract ourselves, reusing the existing markdown infrastructure.

## Changes

- **`next.config.ts`** — `rewrites()` restructured into `beforeFiles`/`afterFiles`. New `beforeFiles` entries negotiate on the `Accept` header:
  - `/` → `/llms.mdx` (the docs index page)
  - `/docs/:slug*` → `/llms.mdx/:slug*`
  - matched when `Accept` contains `text/markdown` (`has` header matcher). `beforeFiles` is required so `/` is intercepted before the homepage page route resolves. Existing `.md`/`.mdx` suffix rewrites are preserved verbatim in `afterFiles`.
- **`app/llms.mdx/[[...slug]]/route.ts`** — responses now send `Content-Type: text/markdown; charset=utf-8`, `Vary: Accept`, and an `x-markdown-tokens` hint.
- **`lib/estimate-tokens.ts`** (new) — dependency-free `~4 chars/token` estimate (named constant, no tokenizer dep).

Reuses the existing `getLLMText()` pipeline. No new dependencies, no middleware.

## Scope

- In scope: `/` and `/docs/*` (confirmed). Reuses the `/llms.mdx` route + `getLLMText()`.
- Out of scope: blog (`/blog/*`, separate Fumadocs collection without processed markdown), JSX/data-driven marketing pages (no markdown source), and `/llms.txt`/`/llms-full.txt` (kept as text/plain, as advertised in the Link header).

## Notes

- **`Vary: Accept` is set on the markdown responses only.** Next.js sets its own `Vary` on HTML page responses and overrides the config-level key (last-wins — the same behavior the existing `Link` comment documents), so a config `Vary` on pages provably no-ops. Rather than ship dead config or add a `middleware.ts` for an advisory header, it's kept where it works. `Vary` is not part of the markdown-negotiation contract.
- **Docs/example:** website-infra behavior, not an xmcp framework feature, so no runnable example project applies.
- Per `apps/website/AGENTS.md` this is a site-only change (normally → `main`); targeting `canary` as requested.

## Verification

`pnpm --filter website build` passes (type-check clean). Manual checks against `next start`:

| Request | Result |
|---|---|
| `/` + `Accept: text/markdown` | `text/markdown; charset=utf-8`, `Vary: Accept`, `x-markdown-tokens: 170` |
| `/docs/getting-started/installation` + markdown | markdown, `Vary: Accept`, `x-markdown-tokens: 916` |
| `/` browser `Accept` | HTML + RFC 8288 `Link` header |
| `/` default `curl` (`*/*`) | HTML (agents must be explicit) |
| `/docs/...installation.md` | markdown (existing path unaffected) |

Final isitagentready.com scan (`markdownNegotiation.status === "pass"`) can only be confirmed after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)