### PR TITLE
feat(website): add WebMCP tools

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -11,6 +11,7 @@ import { Prefooter } from "@/components/layout/prefooter";
 import { Toaster } from "@/components/ui/toaster";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { JsonLd } from "@/components/seo/json-ld";
+import { WebMCPProvider } from "@/components/ai/webmcp-provider";
 import { SITE_URL } from "@/lib/base-url";
 import {
   getOrganizationSchema,
@@ -129,6 +130,7 @@ export default function RootLayout({
           <Toaster />
         </RootProvider>
         <Toolbar />
+        <WebMCPProvider />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/apps/website/components/ai/webmcp-provider.tsx
+++ b/apps/website/components/ai/webmcp-provider.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * WebMCP browser integration.
+ *
+ * Exposes the site's key actions as Web Model Context tools so in-browser AI
+ * agents (and agent-readiness scanners) can discover and call them via
+ * `navigator.modelContext` / `document.modelContext`.
+ *
+ * WebMCP is not natively available in most browsers yet, so we load the
+ * `@mcp-b/global` polyfill. Importing it auto-installs the API on `document`
+ * and `navigator` (same instance) and steps aside when a browser ships native
+ * support. `initializeWebModelContext()` is idempotent and SSR-guarded.
+ *
+ * Tool `execute` handlers reuse existing same-origin endpoints, so there are no
+ * new API routes: `search_docs` hits `/api/search`, `get_doc` uses the
+ * `Accept: text/markdown` content negotiation already wired in `next.config.ts`.
+ *
+ * Spec: https://webmachinelearning.github.io/webmcp/
+ */
+
+type WebMCPContent = { type: "text"; text: string };
+type WebMCPToolResult = { content: WebMCPContent[]; isError?: boolean };
+
+type WebMCPToolAnnotations = {
+  title?: string;
+  readOnlyHint?: boolean;
+  untrustedContentHint?: boolean;
+  openWorldHint?: boolean;
+};
+
+type WebMCPTool = {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema?: Record<string, unknown>;
+  annotations?: WebMCPToolAnnotations;
+  execute: (
+    args: Record<string, unknown>
+  ) => WebMCPToolResult | Promise<WebMCPToolResult>;
+};
+
+type WebMCPModelContext = {
+  registerTool: (
+    tool: WebMCPTool,
+    options?: { signal?: AbortSignal }
+  ) => void | Promise<void>;
+};
+
+function textResult(text: string): WebMCPToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function errorResult(text: string): WebMCPToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeDocSlug(path: string): string | null {
+  const raw = path.trim();
+  if (
+    /^[a-z][a-z0-9+.-]*:/i.test(raw) ||
+    raw.includes("?") ||
+    raw.includes("#")
+  ) {
+    return null;
+  }
+
+  const slug = raw
+    .replace(/^\/+/, "")
+    .replace(/^docs\/?/, "")
+    .replace(/\.(md|mdx)$/, "")
+    .replace(/\/+$/, "");
+
+  if (!slug) return "";
+
+  const segments = slug.split("/");
+  if (
+    segments.some(
+      (segment) =>
+        !segment ||
+        segment === "." ||
+        segment === ".." ||
+        !/^[a-z0-9-]+$/.test(segment)
+    )
+  ) {
+    return null;
+  }
+
+  return segments.join("/");
+}
+
+type SearchResult = { url: string; content: string; type: string };
+
+const TOOLS: WebMCPTool[] = [
+  {
+    name: "search_docs",
+    title: "Search xmcp documentation",
+    description:
+      "Full-text search across the xmcp documentation. Returns a ranked list of matching pages with their titles and URLs. Use get_doc to read a result.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search terms, e.g. 'http transport' or 'api key auth'.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, untrustedContentHint: true },
+    async execute(args) {
+      const query = asString(args.query);
+      if (!query) return errorResult("Provide a non-empty `query`.");
+
+      const res = await fetch(
+        `/api/search?query=${encodeURIComponent(query)}`,
+        { headers: { accept: "application/json" } }
+      );
+      if (!res.ok) return errorResult(`Search failed (HTTP ${res.status}).`);
+
+      const results = (await res.json()) as SearchResult[];
+
+      // The index returns page + heading + text rows; collapse to unique pages,
+      // preferring the page-level row's content as the title.
+      const pages = new Map<string, string>();
+      for (const r of results) {
+        const path = r.url.split("#")[0];
+        if (r.type === "page") pages.set(path, r.content);
+        else if (!pages.has(path)) pages.set(path, path);
+      }
+
+      const top = Array.from(pages.entries()).slice(0, 10);
+      if (top.length === 0) return textResult(`No results for "${query}".`);
+
+      const list = top
+        .map(([url, title], i) => `${i + 1}. ${title} — ${url}`)
+        .join("\n");
+      return textResult(`Found ${top.length} page(s) for "${query}":\n${list}`);
+    },
+  },
+  {
+    name: "get_doc",
+    title: "Read an xmcp documentation page",
+    description:
+      "Fetch the full Markdown of a docs page. Pass a docs path like 'core-concepts/tools' or '/docs/core-concepts/tools'. Omit `path` for the documentation index.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description:
+            "Docs page path (slug). A leading '/docs/' is optional. Empty for the index.",
+        },
+      },
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, untrustedContentHint: true },
+    async execute(args) {
+      const raw = asString(args.path);
+      const slug = normalizeDocSlug(raw);
+
+      if (slug === null) {
+        return errorResult(
+          "Provide a docs path such as 'core-concepts/tools' or '/docs/core-concepts/tools'."
+        );
+      }
+
+      // Empty slug -> docs index. Otherwise the public docs URL with an
+      // Accept: text/markdown header, which next.config.ts rewrites to the
+      // markdown route.
+      const target = slug ? `/docs/${slug}` : "/llms.txt";
+      const res = await fetch(target, { headers: { accept: "text/markdown" } });
+      if (!res.ok) {
+        return errorResult(
+          `No doc found for "${raw || "index"}" (HTTP ${res.status}).`
+        );
+      }
+      return textResult(await res.text());
+    },
+  },
+  {
+    name: "navigate",
+    title: "Navigate to a page on xmcp.dev",
+    description:
+      "Navigate the current browser tab to a same-origin path on the xmcp site, e.g. '/docs/core-concepts/tools' or '/templates'. Only same-origin paths are allowed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description:
+            "Same-origin path beginning with '/'. External URLs are rejected.",
+        },
+      },
+      required: ["path"],
+      additionalProperties: false,
+    },
+    // Performs a real navigation, so it is not read-only.
+    annotations: { readOnlyHint: false },
+    execute(args) {
+      const raw = asString(args.path);
+      if (!raw) return errorResult("Provide a `path`.");
+
+      let resolved: URL;
+      try {
+        resolved = new URL(raw, window.location.origin);
+      } catch {
+        return errorResult(`Invalid path: "${raw}".`);
+      }
+      if (resolved.origin !== window.location.origin) {
+        return errorResult(`Refused: "${raw}" is not same-origin.`);
+      }
+
+      const dest = resolved.pathname + resolved.search + resolved.hash;
+      window.location.assign(dest);
+      return textResult(`Navigating to ${dest}.`);
+    },
+  },
+];
+
+function resolveModelContext(): WebMCPModelContext | undefined {
+  const fromDocument = (
+    document as Document & { modelContext?: WebMCPModelContext }
+  ).modelContext;
+  if (typeof fromDocument?.registerTool === "function") return fromDocument;
+
+  const fromNavigator = (
+    navigator as Navigator & { modelContext?: WebMCPModelContext }
+  ).modelContext;
+  if (typeof fromNavigator?.registerTool === "function") return fromNavigator;
+
+  return undefined;
+}
+
+export function WebMCPProvider() {
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+
+    void (async () => {
+      // Dynamic import keeps the polyfill (and its browser-only dependency
+      // graph) out of the server render pass.
+      const { initializeWebModelContext } = await import("@mcp-b/global");
+      if (cancelled) return;
+
+      initializeWebModelContext();
+
+      const ctx = resolveModelContext();
+      if (!ctx) return;
+
+      try {
+        for (const tool of TOOLS) {
+          await Promise.resolve(
+            ctx.registerTool(tool, { signal: controller.signal })
+          );
+        }
+      } catch (error) {
+        console.warn("[WebMCP] Failed to register tools", error);
+      }
+    })();
+
+    // Aborting unregisters the tools (AbortSignal-driven) on unmount.
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.68",
     "@ai-sdk/react": "^3.0.199",
+    "@mcp-b/global": "^3.0.0",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/mdx": "^16.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@ai-sdk/react':
         specifier: ^3.0.199
         version: 3.0.199(react@19.2.4)(zod@4.1.13)
+      '@mcp-b/global':
+        specifier: ^3.0.0
+        version: 3.0.0(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1(webpack@5.104.1)
@@ -254,7 +257,7 @@ importers:
         version: 5.0.0
       xmcp:
         specifier: latest
-        version: 0.6.9(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.1.13)
+        version: 0.6.13(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.1.13)
       zod:
         specifier: ^4.1.13
         version: 4.1.13
@@ -641,7 +644,7 @@ importers:
     dependencies:
       '@mcp-ui/server':
         specifier: ^5.16.2
-        version: 5.16.2(zod@4.1.13)
+        version: 5.16.2(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       xmcp:
         specifier: workspace:*
         version: link:../../packages/xmcp
@@ -968,7 +971,7 @@ importers:
         version: 5.1.0(esbuild@0.28.1)
       xmcp:
         specifier: latest
-        version: 0.6.9(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.1))(zod@4.1.13)
+        version: 0.6.13(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.1))(zod@4.1.13)
       zod:
         specifier: ^4.0.10
         version: 4.1.13
@@ -1104,7 +1107,7 @@ importers:
         version: 5.9.3
       xmcp:
         specifier: ^0.6.2
-        version: 0.6.2(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3)
+        version: 0.6.2(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3)
 
   packages/plugins/better-auth:
     dependencies:
@@ -1203,7 +1206,7 @@ importers:
         version: 5.9.3
       xmcp:
         specifier: ^0.5.7
-        version: 0.5.7(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3)
+        version: 0.5.7(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3)
 
   packages/plugins/commet:
     dependencies:
@@ -1265,7 +1268,7 @@ importers:
         version: 5.9.3
       xmcp:
         specifier: ^0.6.10
-        version: 0.6.10(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3)
+        version: 0.6.10(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3)
 
   packages/plugins/workos:
     dependencies:
@@ -1290,7 +1293,7 @@ importers:
         version: 5.9.3
       xmcp:
         specifier: ^0.5.7
-        version: 0.5.7(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3)
+        version: 0.5.7(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3)
 
   packages/plugins/x402:
     dependencies:
@@ -1312,13 +1315,13 @@ importers:
         version: 5.9.3
       xmcp:
         specifier: ^0.5.8
-        version: 0.5.8(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@3.25.76)
+        version: 0.5.8(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@3.25.76)
 
   packages/xmcp:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
-        version: 1.26.0(zod@4.4.3)
+        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@rspack/core':
         specifier: ^1.6.7
         version: 1.6.7(@swc/helpers@0.5.15)
@@ -1721,6 +1724,9 @@ packages:
 
   '@bufbuild/protobuf@2.12.0':
     resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@choojs/findup@0.2.1':
     resolution: {integrity: sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==}
@@ -2437,6 +2443,32 @@ packages:
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
+
+  '@mcp-b/global@3.0.0':
+    resolution: {integrity: sha512-HZWlR2Gb5v/ROtg0noiiHfrnHVPYxxhOPPaeYlXvCd6UB/u82Q3lwtCdWQLw66N25Zp9VSMGRR1Eq72yDFqcNQ==}
+    engines: {node: '>=18'}
+
+  '@mcp-b/transports@3.0.0':
+    resolution: {integrity: sha512-WMgeb0P9Bhu+0mN07qkvCo+W9Fucdk9+iyp7wPZYAtQ4ZTcbNuu8Zl1qdNM8oWxXgMbA749w4nUcPsbPaMvSvA==}
+
+  '@mcp-b/webmcp-polyfill@3.0.0':
+    resolution: {integrity: sha512-TCrCOZCTfRWrTp8MpWU8EO4U7r7IvDDaIYW9Ej0aBD2KVR2hvwr4t3T7kPkSYssGhpIZJrq19owSzN1vZabW+A==}
+    engines: {node: '>=18'}
+
+  '@mcp-b/webmcp-ts-sdk@3.0.0':
+    resolution: {integrity: sha512-Lbn7ODKWMYd6xqpcl+OmXseKbjwB+Q3F9CUm9vDFpZgviWc3/5CuG3IDylHg/toVMeZz6v5+E8AmBnv8zj5G5w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25 || ^4.0
+      zod-to-json-schema: ^3.25.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+      zod-to-json-schema:
+        optional: true
+
+  '@mcp-b/webmcp-types@3.0.0':
+    resolution: {integrity: sha512-MmKHNAtlyZoK5khz5GnmgEj/ehk5esoUbgOaFndrlZvpjq3ppmIY3BDrwCv6xaihuuIMOoLLDlf0E65wUd4q7A==}
 
   '@mcp-ui/server@5.16.2':
     resolution: {integrity: sha512-KgdEI5IdM5wrWi658y8ZBw+QWM+3XwTtezWpMKR56LIZOCJjRMhBPWWWAF0mlg/r5ngzrXklvXCQbx79PqFAwQ==}
@@ -8830,8 +8862,8 @@ packages:
       react-dom:
         optional: true
 
-  xmcp@0.6.2:
-    resolution: {integrity: sha512-xY88YcyD/CJab4PAK7b2CCPCian+DQv63wyVv40snVmgD3AFNWp8uZ1d41UqsJl4xN7gyc/XqV/GvhrgBoMbVg==}
+  xmcp@0.6.13:
+    resolution: {integrity: sha512-RGjaBr05bSaG/NF0OUHIUfX4fhZf4oKLF3PtN3fgHZAzpmVYUMyunPPLB+sE15p3fVG8q77nJCLmVyt+6XicbQ==}
     hasBin: true
     peerDependencies:
       react: '>=19.0.0'
@@ -8843,8 +8875,8 @@ packages:
       react-dom:
         optional: true
 
-  xmcp@0.6.9:
-    resolution: {integrity: sha512-aM8QTdeC8vnG90IPdumkv904qv75Jm1FKj4Lt0mMdQ+YqV9Yzm3CBlL8/9Pvm0teM/jjxpvA/0f6JT8yxDNdHA==}
+  xmcp@0.6.2:
+    resolution: {integrity: sha512-xY88YcyD/CJab4PAK7b2CCPCian+DQv63wyVv40snVmgD3AFNWp8uZ1d41UqsJl4xN7gyc/XqV/GvhrgBoMbVg==}
     hasBin: true
     peerDependencies:
       react: '>=19.0.0'
@@ -9289,6 +9321,8 @@ snapshots:
   '@borewit/text-codec@0.2.1': {}
 
   '@bufbuild/protobuf@2.12.0': {}
+
+  '@cfworker/json-schema@4.1.1': {}
 
   '@choojs/findup@0.2.1':
     dependencies:
@@ -9903,9 +9937,50 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
-  '@mcp-ui/server@5.16.2(zod@4.1.13)':
+  '@mcp-b/global@3.0.0(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@4.1.13)
+      '@mcp-b/transports': 3.0.0(zod-to-json-schema@3.25.1(zod@4.1.13))
+      '@mcp-b/webmcp-polyfill': 3.0.0
+      '@mcp-b/webmcp-ts-sdk': 3.0.0(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)
+      '@mcp-b/webmcp-types': 3.0.0
+    transitivePeerDependencies:
+      - zod
+      - zod-to-json-schema
+
+  '@mcp-b/transports@3.0.0(zod-to-json-schema@3.25.1(zod@4.1.13))':
+    dependencies:
+      '@mcp-b/webmcp-ts-sdk': 3.0.0(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - zod-to-json-schema
+
+  '@mcp-b/webmcp-polyfill@3.0.0':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@mcp-b/webmcp-types': 3.0.0
+      '@standard-schema/spec': 1.1.0
+
+  '@mcp-b/webmcp-ts-sdk@3.0.0(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@3.25.76)':
+    dependencies:
+      '@mcp-b/webmcp-polyfill': 3.0.0
+      '@mcp-b/webmcp-types': 3.0.0
+    optionalDependencies:
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@4.1.13)
+
+  '@mcp-b/webmcp-ts-sdk@3.0.0(zod-to-json-schema@3.25.1(zod@4.1.13))(zod@4.1.13)':
+    dependencies:
+      '@mcp-b/webmcp-polyfill': 3.0.0
+      '@mcp-b/webmcp-types': 3.0.0
+    optionalDependencies:
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.1(zod@4.1.13)
+
+  '@mcp-b/webmcp-types@3.0.0': {}
+
+  '@mcp-ui/server@5.16.2(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
@@ -9958,7 +10033,7 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.18.0
@@ -9977,10 +10052,12 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@4.1.13)':
+  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.18.0
@@ -9999,10 +10076,12 @@ snapshots:
       raw-body: 3.0.2
       zod: 4.1.13
       zod-to-json-schema: 3.25.1(zod@4.1.13)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.18.0
@@ -10021,6 +10100,8 @@ snapshots:
       raw-body: 3.0.2
       zod: 4.4.3
       zod-to-json-schema: 3.25.1(zod@4.4.3)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -17493,9 +17574,9 @@ snapshots:
 
   ws@8.21.0: {}
 
-  xmcp@0.5.7(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3):
+  xmcp@0.5.7(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@rspack/core': 1.6.7(@swc/helpers@0.5.15)
       postcss-loader: 8.2.0(@rspack/core@1.6.7(@swc/helpers@0.5.15))(postcss@8.5.14)(typescript@5.9.3)(webpack@5.104.1)
       ts-checker-rspack-plugin: 1.2.1(@rspack/core@1.6.7(@swc/helpers@0.5.15))(typescript@5.9.3)
@@ -17511,9 +17592,9 @@ snapshots:
       - supports-color
       - webpack
 
-  xmcp@0.5.8(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@3.25.76):
+  xmcp@0.5.8(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@3.25.76):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@rspack/core': 1.6.7(@swc/helpers@0.5.15)
       postcss-loader: 8.2.0(@rspack/core@1.6.7(@swc/helpers@0.5.15))(postcss@8.5.14)(typescript@5.9.3)(webpack@5.104.1)
       ts-checker-rspack-plugin: 1.2.1(@rspack/core@1.6.7(@swc/helpers@0.5.15))(typescript@5.9.3)
@@ -17529,9 +17610,9 @@ snapshots:
       - supports-color
       - webpack
 
-  xmcp@0.6.10(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3):
+  xmcp@0.6.10(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@rspack/core': 1.6.7(@swc/helpers@0.5.15)
       jose: 6.1.3
       postcss-loader: 8.2.0(@rspack/core@1.6.7(@swc/helpers@0.5.15))(postcss@8.5.14)(typescript@5.9.3)(webpack@5.104.1)
@@ -17548,27 +17629,9 @@ snapshots:
       - supports-color
       - webpack
 
-  xmcp@0.6.2(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3):
+  xmcp@0.6.13(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.1))(zod@4.1.13):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@4.4.3)
-      '@rspack/core': 1.6.7(@swc/helpers@0.5.15)
-      postcss-loader: 8.2.0(@rspack/core@1.6.7(@swc/helpers@0.5.15))(postcss@8.5.14)(typescript@5.9.3)(webpack@5.104.1)
-      ts-checker-rspack-plugin: 1.2.1(@rspack/core@1.6.7(@swc/helpers@0.5.15))(typescript@5.9.3)
-      typescript: 5.9.3
-      zod: 4.4.3
-    optionalDependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - '@swc/helpers'
-      - postcss
-      - supports-color
-      - webpack
-
-  xmcp@0.6.9(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.1))(zod@4.1.13):
-    dependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@4.1.13)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       '@rspack/core': 1.6.7(@swc/helpers@0.5.15)
       jose: 6.1.3
       postcss-loader: 8.2.0(@rspack/core@1.6.7(@swc/helpers@0.5.15))(postcss@8.5.14)(typescript@5.9.3)(webpack@5.104.1(esbuild@0.28.1))
@@ -17585,15 +17648,33 @@ snapshots:
       - supports-color
       - webpack
 
-  xmcp@0.6.9(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.1.13):
+  xmcp@0.6.13(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.1.13):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@4.1.13)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       '@rspack/core': 1.6.7(@swc/helpers@0.5.15)
       jose: 6.1.3
       postcss-loader: 8.2.0(@rspack/core@1.6.7(@swc/helpers@0.5.15))(postcss@8.5.14)(typescript@5.9.3)(webpack@5.104.1)
       ts-checker-rspack-plugin: 1.2.1(@rspack/core@1.6.7(@swc/helpers@0.5.15))(typescript@5.9.3)
       typescript: 5.9.3
       zod: 4.1.13
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@swc/helpers'
+      - postcss
+      - supports-color
+      - webpack
+
+  xmcp@0.6.2(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.4.3):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@rspack/core': 1.6.7(@swc/helpers@0.5.15)
+      postcss-loader: 8.2.0(@rspack/core@1.6.7(@swc/helpers@0.5.15))(postcss@8.5.14)(typescript@5.9.3)(webpack@5.104.1)
+      ts-checker-rspack-plugin: 1.2.1(@rspack/core@1.6.7(@swc/helpers@0.5.15))(typescript@5.9.3)
+      typescript: 5.9.3
+      zod: 4.4.3
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)


### PR DESCRIPTION
## Summary
- add a client-side WebMCP provider for website docs search, doc reads, and same-origin navigation
- wire the provider into the root layout
- add the @mcp-b/global polyfill dependency
- harden docs path handling to reject traversal, absolute URLs, query strings, and hashes

## Checks
- pnpm --filter website exec tsc --noEmit
- pnpm --filter website exec prettier --write components/ai/webmcp-provider.tsx

## Notes
- pnpm --filter website lint currently fails before linting files with an ESLint config circular structure error under Node v26.0.0; repo guidance expects Node 20.