### PR TITLE
feat(xmcp): serve MCP Server Card at /.well-known/mcp/server-card.json

### DIFF
--- a/apps/website/content/docs/discoverability/mcp-server-card.mdx
+++ b/apps/website/content/docs/discoverability/mcp-server-card.mdx
@@ -1,0 +1,71 @@
+---
+title: "MCP Server Card"
+metadataTitle: "MCP Server Card | xmcp Documentation"
+publishedAt: "2026-06-26"
+summary: "xmcp automatically serves an MCP Server Card at /.well-known/mcp/server-card.json so agent discovery tools can find and auto-configure connections to your server."
+description: "Serve an MCP Server Card for automatic agent discovery."
+---
+
+xmcp automatically publishes an [MCP Server Card](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) at `/.well-known/mcp/server-card.json`. This lets agent discovery tools find your server and auto-configure a connection without any manual setup.
+
+The card is built from the `serverInfo` fields in your `xmcp.config.ts`:
+
+```typescript title="xmcp.config.ts"
+import type { XmcpConfig } from "xmcp";
+
+const config: XmcpConfig = {
+  http: true,
+  template: {
+    name: "My MCP Server",
+    description: "Describe what your server does.",
+    icons: [{ src: "https://example.com/icon.png", mimeType: "image/png" }],
+  },
+};
+
+export default config;
+```
+
+## Standalone HTTP servers
+
+No extra setup needed. Every xmcp HTTP server exposes the card automatically:
+
+```bash
+curl https://your-server.example.com/.well-known/mcp/server-card.json
+```
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
+  "name": "com.example.your-server/mcp",
+  "version": "1.0.0",
+  "title": "My MCP Server",
+  "description": "Describe what your server does.",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://your-server.example.com/mcp"
+    }
+  ]
+}
+```
+
+## Next.js adapter
+
+When using the Next.js adapter, add a single route file to expose the card:
+
+```typescript title="app/.well-known/mcp/server-card.json/route.ts"
+import { serverCardHandler } from "@xmcp/adapter";
+export { serverCardHandler as GET };
+```
+
+## Validation
+
+After deploying, verify your server card is discoverable:
+
+```bash
+curl -s https://isitagentready.com/api/scan \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://your-server.example.com"}'
+```
+
+Look for `checks.discovery.mcpServerCard.status === "pass"` in the response.

--- a/apps/website/content/docs/discoverability/mcp-server-card.mdx
+++ b/apps/website/content/docs/discoverability/mcp-server-card.mdx
@@ -51,7 +51,9 @@ curl https://your-server.example.com/.well-known/mcp/server-card.json
 
 ## Next.js adapter
 
-When using the Next.js adapter, add a single route file to expose the card:
+The route is not scaffolded automatically because not every project needs it. Add it manually when you want discovery:
+
+
 
 ```typescript title="app/.well-known/mcp/server-card.json/route.ts"
 import { serverCardHandler } from "@xmcp/adapter";

--- a/apps/website/content/docs/discoverability/meta.json
+++ b/apps/website/content/docs/discoverability/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Discoverability",
-  "pages": ["smithery"],
+  "pages": ["smithery", "mcp-server-card"],
   "defaultOpen": true,
   "root": true
 }

--- a/examples/with-nextjs/src/app/.well-known/mcp/server-card.json/route.ts
+++ b/examples/with-nextjs/src/app/.well-known/mcp/server-card.json/route.ts
@@ -1,0 +1,3 @@
+import { serverCardHandler } from "@xmcp/adapter";
+
+export { serverCardHandler as GET };

--- a/packages/xmcp/src/runtime/adapters/nextjs/index.ts
+++ b/packages/xmcp/src/runtime/adapters/nextjs/index.ts
@@ -80,3 +80,42 @@ export {
   type AuthConfig,
   type OAuthProtectedResourceMetadata,
 } from "./auth";
+
+/**
+ * MCP Server Card handler for Next.js route files (SEP-1649).
+ * Serves server identity and transport metadata at `/.well-known/mcp/server-card.json`,
+ * enabling agent discovery clients to auto-configure connections.
+ *
+ * @example
+ * // app/.well-known/mcp/server-card.json/route.ts
+ * import { serverCardHandler } from "@xmcp/adapter";
+ * export { serverCardHandler as GET };
+ */
+export function serverCardHandler(request: Request): Response {
+  const url = new URL(request.url);
+  const reversedName = url.hostname.split(".").reverse().join(".");
+  const card: Record<string, unknown> = {
+    $schema:
+      "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
+    name: `${reversedName}/mcp`,
+    version: SERVER_INFO.version,
+    description: TEMPLATE_CONFIG.description,
+    title: TEMPLATE_CONFIG.name,
+    remotes: [
+      {
+        type: "streamable-http",
+        url: `${url.origin}${HTTP_CONFIG.endpoint}`,
+      },
+    ],
+  };
+  if (TEMPLATE_CONFIG.icons?.length) {
+    card.icons = TEMPLATE_CONFIG.icons;
+  }
+  return Response.json(card, {
+    headers: {
+      "Content-Type": "application/mcp-server-card+json",
+      "Cache-Control": "public, max-age=3600, must-revalidate",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
+++ b/packages/xmcp/src/runtime/transports/http/stateless-streamable-http.ts
@@ -187,6 +187,7 @@ export class StatelessStreamableHTTPTransport {
       );
     });
 
+    this.setupMcpServerCardRoute();
     this.setupOpenAIAppsChallengeRoute();
 
     // isolate requests context
@@ -196,6 +197,47 @@ export class StatelessStreamableHTTPTransport {
         next();
       });
     });
+  }
+
+  /**
+   * Serves an MCP Server Card at /.well-known/mcp/server-card.json.
+   * Enables agent discovery clients to auto-configure connections to this server.
+   */
+  private setupMcpServerCardRoute(): void {
+    this.app.get(
+      "/.well-known/mcp/server-card.json",
+      (req: Request, res: Response) => {
+        const host = req.get("host") ?? "localhost";
+        const hostname = host.replace(/:\d+$/, "");
+        const reversedName = hostname.split(".").reverse().join(".");
+        const proto =
+          (req.headers["x-forwarded-proto"] as string | undefined)
+            ?.split(",")[0]
+            ?.trim() ?? req.protocol;
+        const card: Record<string, unknown> = {
+          $schema:
+            "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
+          name: `${reversedName}/mcp`,
+          version: SERVER_INFO.version,
+          description: this.options.template?.description,
+          title: this.options.template?.name,
+          remotes: [
+            {
+              type: "streamable-http",
+              url: `${proto}://${host}${this.endpoint}`,
+            },
+          ],
+        };
+        if (this.options.template?.icons?.length) {
+          card.icons = this.options.template.icons;
+        }
+        res
+          .setHeader("Content-Type", "application/mcp-server-card+json")
+          .setHeader("Cache-Control", "public, max-age=3600, must-revalidate")
+          .setHeader("Access-Control-Allow-Origin", "*")
+          .json(card);
+      }
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

- Standalone HTTP servers automatically expose `/.well-known/mcp/server-card.json` via a new `setupMcpServerCardRoute()` method in `StatelessStreamableHTTPTransport`. No user config required.
- Next.js adapter exports `serverCardHandler` for opt-in wiring (same convention as `resourceMetadataHandler` for OAuth).
- `remotes[0].url` respects `X-Forwarded-Proto` so the scheme is correct behind TLS-terminating proxies.
- Docs page added to the `discoverability/` section. Example route added to `examples/with-nextjs`.

## Test plan

- [ ] `cd packages/xmcp && bash build-and-link.sh`
- [ ] `cd examples/http-transport && pnpm dev` → `curl -s http://localhost:3001/.well-known/mcp/server-card.json | jq .` — confirm all fields present
- [ ] `curl -s -H "x-forwarded-proto: https" http://localhost:3001/.well-known/mcp/server-card.json | jq '.remotes[0].url'` — confirm `https://` scheme
- [ ] `cd examples/with-nextjs && pnpm dev` → `curl -s http://localhost:3000/.well-known/mcp/server-card.json | jq .` — confirm Next.js adapter path