### PR TITLE
feat(website): publish Agent Skills discovery index

### DIFF
--- a/apps/website/agent-skills/create-tool/SKILL.md
+++ b/apps/website/agent-skills/create-tool/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: create-tool
+description: Create a new xmcp tool with schema, metadata, and handler. Use when the user wants to add a new tool to their xmcp project.
+metadata:
+  argument-hint: "[tool-name]"
+---
+
+# Create xmcp Tool
+
+You are helping the user create a new xmcp tool. Follow this interactive workflow.
+
+## Step 1: Gather Information
+
+Before generating any code, ask the user these questions using AskUserQuestion:
+
+1. **Tool name** (if not provided as argument): What should the tool be named? (Use kebab-case)
+
+2. **Handler type**: Ask which handler type they need:
+   - **Standard** - For data queries, calculations, API calls (returns string/JSON)
+   - **Template Literal (HTML)** - For HTML widgets with external scripts
+   - **React Component** - For interactive stateful widgets (.tsx file)
+
+3. **Schema fields**: What parameters should the tool accept? Ask for:
+   - Parameter name
+   - Type (string, number, boolean, enum, array, object)
+   - Description
+   - Whether it's optional
+   - Any validation rules
+
+4. **Annotations**: Ask about behavior hints:
+   - Is it read-only? (doesn't modify environment)
+   - Is it destructive? (may delete or modify data)
+   - Is it idempotent? (repeated calls have same effect)
+   - Does it interact with external world? (openWorldHint)
+
+5. **Widget support** (if Template Literal or React): Ask if they need:
+   - OpenAI tool invocation messages (invoking/invoked status)
+   - Widget accessibility (widgetAccessible)
+   - Widget-to-tool communication
+
+## Step 2: Generate the Tool
+
+Create the tool file in `src/tools/` with the appropriate extension:
+- `.ts` for Standard and Template Literal handlers
+- `.tsx` for React Component handlers
+
+### File Location
+```
+src/tools/{tool-name}.ts   # or .tsx for React
+```
+
+## Tool Structure Reference
+
+Every xmcp tool has three main exports:
+
+```typescript
+// 1. Schema (optional) - Define parameters with Zod
+export const schema = { /* ... */ };
+
+// 2. Metadata (optional) - Tool configuration
+export const metadata: ToolMetadata = { /* ... */ };
+
+// 3. Handler (required) - Default export function
+export default function handler(params) { /* ... */ }
+```
+
+## Quick Reference
+
+### Essential Imports
+```typescript
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+```
+
+### Handler Types Summary
+
+| Type | Use Case | File Extension |
+|------|----------|----------------|
+| Standard (string) | Simple queries, calculations | `.ts` |
+| Standard (async) | API calls, database queries | `.ts` |
+| Template Literal | HTML widgets, iframes, scripts | `.ts` |
+| React Component | Interactive stateful UIs | `.tsx` |
+| No Parameters | Tools that don't need input | `.ts` |
+| With Extra Args | Auth/context-dependent tools | `.ts` |
+
+### Annotations Quick Reference
+
+| Annotation | Use When |
+|------------|----------|
+| `readOnlyHint: true` | Tool doesn't modify environment |
+| `destructiveHint: true` | Tool may delete/modify data |
+| `idempotentHint: true` | Repeated calls have same effect |
+| `openWorldHint: true` | Tool interacts with external world |
+
+## Detailed Templates
+
+For complete code templates including:
+- Schema patterns (simple, validation, enum, optional, object)
+- Metadata patterns (basic, annotations, OpenAI widgets, MCP Apps UI)
+- All handler type templates (A through G)
+- Return value patterns
+- Type imports reference
+
+**Read: `references/templates.md`**
+
+---
+
+## Checklist After Generation
+
+1. File created in `src/tools/{tool-name}.ts` (or `.tsx`)
+2. Schema uses `.describe()` for all parameters
+3. If using metadata, ensure it has descriptive `name` and `description`
+4. Appropriate annotations set based on tool behavior
+5. Handler matches the chosen type
+6. All imports are correct
+
+Suggest running `pnpm build` to verify the tool compiles correctly.

--- a/apps/website/agent-skills/create-tool/references/templates.md
+++ b/apps/website/agent-skills/create-tool/references/templates.md
@@ -1,0 +1,409 @@
+# xmcp Tool Templates Reference
+
+This file contains detailed code templates for creating xmcp tools. Use these patterns when generating tool code.
+
+---
+
+## Schema Patterns
+
+### Simple Schema
+```typescript
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+
+export const schema = {
+  name: z.string().describe("The user's name"),
+};
+```
+
+### Schema with Validation
+```typescript
+export const schema = {
+  input: z
+    .string()
+    .min(1, "Input is required")
+    .max(1000, "Input too long")
+    .describe("The input text to process"),
+  count: z
+    .number()
+    .int()
+    .positive()
+    .default(10)
+    .describe("Number of results"),
+};
+```
+
+### Schema with Enum
+```typescript
+export const schema = {
+  format: z
+    .enum(["json", "csv", "xml"])
+    .describe("Output format"),
+};
+```
+
+### Schema with Optional Fields
+```typescript
+export const schema = {
+  query: z.string().describe("Search query"),
+  limit: z.number().optional().describe("Max results"),
+  filters: z.array(z.string()).optional().describe("Filter tags"),
+};
+```
+
+### Schema with Object
+```typescript
+export const schema = {
+  config: z.object({
+    enabled: z.boolean(),
+    threshold: z.number(),
+  }).describe("Configuration object"),
+};
+```
+
+---
+
+## Metadata Patterns
+
+### Basic Metadata
+```typescript
+export const metadata: ToolMetadata = {
+  name: "my-tool",
+  description: "Brief description of what this tool does",
+};
+```
+
+### Minimal Tool (No Metadata)
+```typescript
+import { z } from "zod";
+import { type InferSchema } from "xmcp";
+
+export const schema = {
+  name: z.string().describe("The name to greet"),
+};
+
+// Metadata is optional - tool name defaults to filename
+export default function handler({ name }: InferSchema<typeof schema>) {
+  return `Hello, ${name}!`;
+}
+```
+
+**Note:** When metadata is omitted, xmcp uses the filename as the tool name.
+
+### Metadata with Annotations
+```typescript
+export const metadata: ToolMetadata = {
+  name: "my-tool",
+  description: "Brief description of what this tool does",
+  annotations: {
+    title: "My Tool",           // Human-readable title
+    readOnlyHint: true,         // Doesn't modify environment
+    destructiveHint: false,     // Doesn't delete/modify data
+    idempotentHint: true,       // Repeated calls = same result
+    openWorldHint: false,       // Doesn't interact with external world
+  },
+};
+```
+
+### Metadata with OpenAI Widget Support
+```typescript
+export const metadata: ToolMetadata = {
+  name: "my-widget",
+  description: "Interactive widget tool",
+  annotations: {
+    title: "My Widget",
+    readOnlyHint: true,
+  },
+  _meta: {
+    openai: {
+      toolInvocation: {
+        invoking: "Loading widget...",    // Max 64 chars
+        invoked: "Widget ready!",         // Max 64 chars
+      },
+      widgetAccessible: true,             // Enables widget-to-tool communication
+      resultCanProduceWidget: true,       // For React/HTML widgets
+    },
+  },
+};
+```
+
+### Metadata with MCP Apps UI Support
+```typescript
+export const metadata: ToolMetadata = {
+  name: "my-tool",
+  description: "Tool with UI metadata",
+  _meta: {
+    ui: {
+      toolInvocation: {
+        invoking: "Processing...",
+        invoked: "Complete!",
+      },
+      widgetAccessible: true,
+    },
+  },
+};
+```
+
+---
+
+## Handler Type Templates
+
+### Template A: Standard Handler (String Return)
+
+Best for: Data queries, calculations, simple API calls
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+
+export const schema = {
+  name: z.string().describe("The name to greet"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "greet",
+  description: "Greet a user by name",
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
+};
+
+export default function handler({ name }: InferSchema<typeof schema>) {
+  return `Hello, ${name}!`;
+}
+```
+
+### Template B: Standard Handler (Async with Content Array)
+
+Best for: API calls, database queries, file operations
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+
+export const schema = {
+  query: z.string().describe("Search query"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "search",
+  description: "Search for items",
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+};
+
+export default async function handler({ query }: InferSchema<typeof schema>) {
+  const results = await performSearch(query);
+
+  return JSON.stringify(results, null, 2);
+}
+```
+
+### Template C: Standard Handler (Structured Content)
+
+Best for: Returning typed data that clients can parse
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+
+export const schema = {
+  city: z.string().describe("City name"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "get-weather",
+  description: "Get weather data for a city",
+};
+
+export default async function handler({ city }: InferSchema<typeof schema>) {
+  const weather = await fetchWeather(city);
+
+  return JSON.stringify(weather);
+}
+```
+
+### Template D: Template Literal (HTML Widget)
+
+Best for: Embedding external widgets, iframes, or scripts
+
+```typescript
+import { type ToolMetadata } from "xmcp";
+
+export const metadata: ToolMetadata = {
+  name: "show-map",
+  description: "Display an interactive map",
+  _meta: {
+    openai: {
+      toolInvocation: {
+        invoking: "Loading map...",
+        invoked: "Map ready!",
+      },
+      resultCanProduceWidget: true,
+    },
+  },
+};
+
+export default async function handler() {
+  return `
+    <div id="map-root" style="width: 100%; height: 400px;"></div>
+    <link rel="stylesheet" href="{{MAP_WIDGET_CSS_URL}}">
+    <script type="module" src="{{MAP_WIDGET_JS_URL}}"></script>
+  `.trim();
+}
+```
+
+### Template E: React Component
+
+Best for: Interactive stateful widgets, complex UIs
+
+**File: `src/tools/my-widget.tsx`**
+
+```tsx
+import { useState, useEffect } from "react";
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+
+export const schema = {
+  initialValue: z.number().default(0).describe("Starting value"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "counter",
+  description: "Interactive counter widget",
+  _meta: {
+    openai: {
+      toolInvocation: {
+        invoking: "Loading counter...",
+        invoked: "Counter ready!",
+      },
+      widgetAccessible: true,
+      resultCanProduceWidget: true,
+    },
+  },
+};
+
+export default function handler({ initialValue }: InferSchema<typeof schema>) {
+  const [count, setCount] = useState(initialValue);
+
+  return (
+    <div style={{ padding: "20px", textAlign: "center" }}>
+      <h2>Count: {count}</h2>
+      <button onClick={() => setCount(count + 1)}>+</button>
+      <button onClick={() => setCount(count - 1)}>-</button>
+      <button onClick={() => setCount(initialValue)}>Reset</button>
+    </div>
+  );
+}
+```
+
+### Template F: No Parameters
+
+Best for: Tools that don't need input
+
+```typescript
+import { type ToolMetadata } from "xmcp";
+
+export const metadata: ToolMetadata = {
+  name: "get-timestamp",
+  description: "Get current timestamp",
+  annotations: {
+    readOnlyHint: true,
+  },
+};
+
+export default function handler() {
+  return new Date().toISOString();
+}
+```
+
+### Template G: With Extra Arguments (Auth/Context)
+
+Best for: Tools that need authentication or request context
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata, type ToolExtraArguments } from "xmcp";
+
+export const schema = {
+  resourceId: z.string().describe("Resource to access"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "get-resource",
+  description: "Get a protected resource",
+};
+
+export default async function handler(
+  { resourceId }: InferSchema<typeof schema>,
+  extra: ToolExtraArguments
+) {
+  // Access auth info
+  if (!extra.authInfo) {
+    return { content: [{ type: "text", text: "Unauthorized" }], isError: true };
+  }
+
+  const { token, scopes, clientId } = extra.authInfo;
+
+  // Access other context
+  const { sessionId, requestId, signal } = extra;
+
+  // Fetch with abort support
+  const response = await fetch(`/api/resource/${resourceId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal,
+  });
+
+  return await response.text();
+}
+```
+
+---
+
+## Return Value Patterns
+
+### Simple String (Preferred for readability)
+```typescript
+return `Result: ${value}`;
+return JSON.stringify(data, null, 2);
+```
+
+### Error Response
+```typescript
+return {
+  content: [{ type: "text", text: "Error: Something went wrong" }],
+  isError: true,
+};
+```
+
+### HTML String (Auto-wrapped as widget)
+```typescript
+return `<div>HTML content</div>`;
+```
+
+### JSX (React handlers only)
+```tsx
+return <MyComponent prop={value} />;
+```
+
+---
+
+## Type Imports Reference
+
+```typescript
+// Core types
+import {
+  type ToolMetadata,
+  type ToolExtraArguments,
+  type InferSchema,
+} from "xmcp";
+
+// Zod for schemas
+import { z } from "zod";
+
+// React (for .tsx files)
+import { useState, useEffect } from "react";
+```

--- a/apps/website/agent-skills/mcp-server-design/SKILL.md
+++ b/apps/website/agent-skills/mcp-server-design/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: mcp-server-design
+description: Guide for designing effective MCP servers with agent-friendly tools. Use when creating a new MCP server, designing MCP tools, or improving existing MCP server architecture.
+---
+
+# MCP Server Design
+
+## Overview
+
+This skill provides best practices for designing MCP (Model Context Protocol) servers that work effectively with LLM agents. The key insight: design for agents, not automation. LLMs are human-like thinkers, not API consumers.
+
+## Core Philosophy
+
+### Design for Agents, Not Automation
+
+Traditional API design optimizes for programmatic access with granular endpoints. MCP tool design should optimize for how LLMs think and reason:
+
+- **LLMs are human-like thinkers**: They understand intent, context, and purpose
+- **Tools should be tasks, not endpoints**: Shape tools around what users want to accomplish
+- **Reduce cognitive load**: Fewer, more purposeful tools beat many granular ones
+
+### The Three Pillars
+
+1. **Give everything ready**: Provide complete, actionable information
+2. **Reduce effort**: Minimize steps needed to accomplish tasks
+3. **Reduce paths**: Limit decision branches the LLM must navigate
+
+## Tool Design Principles
+
+### 1. Purpose-Built Tools Over Generic Wrappers
+
+**Anti-pattern**: Wrapping every API endpoint as a tool
+```typescript
+// Bad: Generic database tools
+// src/tools/run-sql.ts
+// src/tools/list-tables.ts
+// src/tools/describe-table.ts
+```
+
+**Best practice**: Design tools around user tasks
+```typescript
+// Good: Task-oriented tools
+// src/tools/prepare-database-migration.ts
+import { z } from "zod";
+import type { ToolMetadata } from "xmcp";
+
+export const schema = {
+  description: z.string().describe("What database changes are needed"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "prepare-database-migration",
+  description: "Design a database change with safety checks and reviewed migration plan",
+};
+
+// src/tools/analyze-slow-queries.ts
+// src/tools/create-backup.ts
+```
+
+### 2. Minimize Tool Count
+
+LLMs struggle with long tool lists. Each additional tool:
+- Increases selection confusion
+- Adds tokens to every request
+- Dilutes the purpose of each tool
+
+**Guidelines**:
+- Start with 5-10 core tools
+- Add tools only when evals show they're needed
+- Combine related operations when sensible
+
+### 3. Name Tools for Purpose, Not Implementation
+
+Tool names guide LLM behavior. The name should describe the task, not the mechanism.
+
+| Instead of... | Use... |
+|---------------|--------|
+| `post-slack-message` | `notify-team` |
+| `run-sql-query` | `analyze-data` |
+| `call-api-endpoint` | `check-service-status` |
+
+### 4. Shape Tools Like Tasks
+
+For complex flows, one tool per task beats one tool per step.
+
+**Anti-pattern**: Breaking deployment into atomic operations
+```typescript
+// Bad: Too many granular tools
+// src/tools/create-branch.ts
+// src/tools/commit-changes.ts
+// src/tools/push-branch.ts
+// src/tools/create-pr.ts
+// src/tools/run-tests.ts
+// src/tools/merge-pr.ts
+```
+
+**Best practice**: Single tool for the complete task
+```typescript
+// src/tools/deploy-changes.ts
+import { z } from "zod";
+import type { ToolMetadata } from "xmcp";
+
+export const schema = {
+  description: z.string().describe("What changes are being deployed"),
+  runTests: z.boolean().default(true).describe("Run test suite first"),
+  autoMerge: z.boolean().default(false).describe("Auto-merge after tests pass"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "deploy-changes",
+  description: "Deploy current changes through the complete workflow",
+};
+
+export default function deployChanges({ description, runTests, autoMerge }) {
+  // Handles: branch creation, commit, push, PR, tests, merge
+}
+```
+
+## Decision Framework
+
+### When to Create a New Tool
+
+Create a new tool when:
+- Users frequently ask for this specific capability
+- The task has clear boundaries and purpose
+- Existing tools can't accomplish it cleanly
+- Evals show the LLM selects incorrect tools for this task
+
+Don't create a new tool when:
+- An existing tool can handle it with minor parameter changes
+- It duplicates functionality (combine instead)
+- It's a rare edge case (handle with existing tools + guidance)
+
+### When to Combine Operations
+
+Combine multiple operations into one tool when:
+- They're almost always used together
+- The intermediate results aren't useful alone
+- Splitting them creates unnecessary decision points
+
+Keep operations separate when:
+- Users need granular control
+- Intermediate results have standalone value
+- Combining would create an overly complex tool
+
+### Balancing Granularity
+
+| Granular Tools | Combined Tools |
+|----------------|----------------|
+| More flexibility | Simpler mental model |
+| Higher selection burden | Clearer intent |
+| Risk of misuse | Less customizable |
+
+## Quick Reference
+
+### Tool Design Checklist
+
+- [ ] Named for purpose, not implementation
+- [ ] Description explains when to use it
+- [ ] Parameters have clear descriptions
+- [ ] Response includes next steps or context
+- [ ] Tested with actual LLM requests
+
+### Red Flags
+
+- More than 15 tools in a single server
+- Tools named after HTTP methods or endpoints
+- Generic tools that "can do anything"
+- Tools that require multiple calls for a single task
+
+## Resources
+
+### references/
+
+- `design-principles.md` - Extended examples, anti-patterns, and real-world case studies
+
+For deeper exploration of these concepts, read the design principles reference document.

--- a/apps/website/agent-skills/mcp-server-design/references/design-principles.md
+++ b/apps/website/agent-skills/mcp-server-design/references/design-principles.md
@@ -1,0 +1,254 @@
+# MCP Design Principles: Deep Dive
+
+This document provides extended examples, anti-patterns, and real-world case studies for designing effective MCP servers.
+
+## Understanding MCP Fundamentals
+
+### The Three Primitives
+
+MCP servers expose three types of primitives:
+
+1. **Tools**: Actions the LLM can take (most important)
+2. **Resources**: Data the LLM can read
+3. **Prompts**: Pre-built conversation starters
+
+**Tools are the most critical primitive**. They determine what your MCP server can actually do and how effectively LLMs can use it.
+
+## Extended Design Examples
+
+### Case Study: Database Management
+
+#### The Wrong Approach
+
+A developer wraps their PostgreSQL API:
+
+```typescript
+// Anti-pattern: Generic database wrappers
+// src/tools/execute-query.ts
+// src/tools/list-schemas.ts
+// src/tools/list-tables.ts
+// src/tools/describe-table.ts
+// src/tools/get-table-data.ts
+// src/tools/insert-row.ts
+// src/tools/update-row.ts
+// src/tools/delete-row.ts
+// src/tools/create-table.ts
+// src/tools/drop-table.ts
+// src/tools/create-index.ts
+// src/tools/analyze-table.ts
+// src/tools/vacuum-table.ts
+// src/tools/get-query-plan.ts
+// src/tools/list-users.ts
+// src/tools/grant-permission.ts
+```
+
+**Problems**:
+- Generic names don't guide behavior
+- LLM must understand PostgreSQL internals
+- High risk of destructive operations
+
+#### The Right Approach
+
+Design around what database users actually need:
+
+```typescript
+// src/tools/explore-database.ts
+import { z } from "zod";
+import type { ToolMetadata } from "xmcp";
+
+export const schema = {};
+
+export const metadata: ToolMetadata = {
+  name: "explore-database",
+  description: "Understand database structure. Returns schemas, tables, relationships, and sample data to help answer questions.",
+};
+
+// src/tools/query-data.ts
+export const schema = {
+  question: z.string().describe("What you want to know about the data"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "query-data",
+  description: "Answer questions about data. Describe what you want to know and get formatted results with insights.",
+};
+
+// src/tools/prepare-migration.ts
+export const schema = {
+  description: z.string().describe("What database change is needed"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "prepare-migration",
+  description: "Design a database change. Describe the change needed and get a reviewed migration plan with safety checks.",
+};
+
+// src/tools/optimize-performance.ts
+export const metadata: ToolMetadata = {
+  name: "optimize-performance",
+  description: "Identify and fix slow queries. Analyzes recent query patterns and suggests specific improvements.",
+};
+
+// src/tools/backup-restore.ts
+export const metadata: ToolMetadata = {
+  name: "backup-restore",
+  description: "Create backups or restore from existing ones. Handles all safety checks automatically.",
+};
+```
+
+**Benefits**:
+- Tools with clear purposes
+- Names describe user goals
+- Built-in safety checks
+- LLM can reason about tasks, not SQL
+
+### Case Study: Communication Platform (Slack-like)
+
+#### The Wrong Approach
+
+```typescript
+// Anti-pattern: API wrapper
+// src/tools/post-message.ts
+// src/tools/update-message.ts
+// src/tools/delete-message.ts
+// src/tools/add-reaction.ts
+// src/tools/remove-reaction.ts
+// src/tools/get-channel-history.ts
+// src/tools/list-channels.ts
+// src/tools/create-channel.ts
+// src/tools/invite-user.ts
+// src/tools/upload-file.ts
+// src/tools/search-messages.ts
+```
+
+#### The Right Approach
+
+```typescript
+// src/tools/notify-team.ts
+import { z } from "zod";
+import type { ToolMetadata } from "xmcp";
+
+export const schema = {
+  message: z.string().describe("The update to send to the team"),
+  urgency: z.enum(["low", "normal", "high"]).default("normal").describe("Message urgency level"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "notify-team",
+  description: "Send updates to team members. Handles channel selection, formatting, and mentions automatically based on urgency and topic.",
+};
+
+// src/tools/find-discussion.ts
+export const schema = {
+  topic: z.string().describe("What topic or context to search for"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "find-discussion",
+  description: "Find relevant conversations and context. Searches across channels and threads to surface related discussions.",
+};
+
+// src/tools/summarize-channel.ts
+export const schema = {
+  channel: z.string().describe("Channel name or ID to summarize"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "summarize-channel",
+  description: "Get caught up on a channel. Returns key discussions, decisions, and action items from recent activity.",
+};
+
+// src/tools/coordinate-meeting.ts
+export const schema = {
+  topic: z.string().describe("Meeting topic"),
+  participants: z.array(z.string()).describe("List of participants"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "coordinate-meeting",
+  description: "Schedule and announce meetings. Finds available times, creates calendar events, and notifies participants.",
+};
+```
+
+## Anti-Patterns in Detail
+
+### Anti-Pattern 1: The "Run Anything" Tool
+
+```typescript
+// Terrible: God tool
+// src/tools/execute.ts
+export const metadata: ToolMetadata = {
+  name: "execute",
+  description: "Execute any operation. Pass the operation type and parameters.",
+};
+```
+
+**Why it's bad**:
+- LLM has no guidance on capabilities
+- Impossible to validate inputs
+- No guardrails on dangerous operations
+
+### Anti-Pattern 2: Implementation Leakage
+
+```typescript
+// Bad: Exposing implementation details
+// src/tools/POST_api_v2_users_create.ts
+export const metadata: ToolMetadata = {
+  name: "POST_api_v2_users_create",
+  description: "Create user via POST /api/v2/users",
+};
+
+// src/tools/GET_api_v2_users_list.ts
+export const metadata: ToolMetadata = {
+  name: "GET_api_v2_users_list",
+  description: "List users via GET /api/v2/users",
+};
+```
+
+**Why it's bad**:
+- HTTP methods are irrelevant to users
+- API versions create confusion
+- Names don't describe user intent
+- Couples tool design to API structure
+
+### Anti-Pattern 3: Incomplete Operations
+
+```typescript
+// Bad: Requiring manual orchestration
+// LLM must call all 4 tools in sequence:
+// src/tools/validate-email.ts
+// src/tools/check-username-available.ts
+// src/tools/create-user-record.ts
+// src/tools/send-welcome-email.ts
+```
+
+**Why it's bad**:
+- Each step is a potential failure point
+- LLM must understand correct ordering
+- Intermediate states may be invalid
+- User asked for one thing, gets four tool calls
+
+**Better approach**:
+```typescript
+// src/tools/create-user.ts
+import { z } from "zod";
+import type { ToolMetadata } from "xmcp";
+
+export const schema = {
+  email: z.string().email().describe("User's email address"),
+  username: z.string().describe("Desired username"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "create-user",
+  description: "Create a new user account. Validates email, checks username availability, creates the account, and sends welcome email. Returns the new user profile or specific validation errors.",
+};
+```
+
+## Summary
+
+Effective MCP server design requires shifting from "what can my API do?" to "what do users need to accomplish?". The best MCP servers:
+
+1. Have few, purposeful tools (5-10)
+2. Name tools for user intent, not implementation
+3. Shape tools around complete tasks

--- a/apps/website/agent-skills/prompt-design/SKILL.md
+++ b/apps/website/agent-skills/prompt-design/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: prompt-design
+description: Design MCP prompts to expose reusable prompt templates. Use when creating parameterized prompts in xmcp.
+---
+
+# Create xmcp Prompt
+
+You are helping the user create a new xmcp prompt. Follow this interactive workflow.
+
+## Step 1: Gather Information
+
+Before generating any code, ask the user these questions using AskUserQuestion:
+
+1. **Prompt name** (if not provided): What should the prompt be named? (Use kebab-case)
+
+2. **Prompt type**: Ask which type of prompt they need:
+   - **Simple** - Static prompt text without parameters
+   - **Parameterized** - Prompt with user-provided parameters (most common)
+   - **Multi-content** - Returns multiple content blocks (text, images, etc.)
+
+3. **Parameters** (if parameterized): What inputs should the prompt accept?
+   - Parameter name
+   - Type (string, number, enum)
+   - Description
+   - Whether it's optional
+   - Any validation or default values
+
+4. **Role**: What role should the prompt assume?
+   - **user** - Prompt from user perspective (most common)
+   - **assistant** - Prompt as assistant response template
+
+5. **Use case**: What is the prompt designed for?
+   - Code review
+   - Documentation generation
+   - Data analysis
+   - Content creation
+   - Other specific task
+
+## Step 2: Generate the Prompt
+
+Create the prompt file in `src/prompts/`:
+
+### File Location
+```
+src/prompts/{prompt-name}.ts
+```
+
+## Prompt Structure Reference
+
+Every xmcp prompt has three main exports:
+
+```typescript
+// 1. Schema (optional) - Define parameters with Zod
+export const schema = { /* ... */ };
+
+// 2. Metadata (optional) - Prompt configuration
+export const metadata: PromptMetadata = { /* ... */ };
+
+// 3. Handler (required) - Default export function
+export default function handler(params?) { /* ... */ }
+```
+
+## Quick Reference
+
+### Essential Imports
+```typescript
+import { type PromptMetadata } from "xmcp";
+
+// For parameterized prompts
+import { z } from "zod";
+import { type InferSchema, type PromptMetadata } from "xmcp";
+```
+
+### Metadata Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | No* | Unique prompt identifier |
+| `title` | string | No | Human-readable title |
+| `description` | string | No | What this prompt does |
+| `role` | string | No | "user" or "assistant" (default: user) |
+
+*When metadata is omitted, xmcp uses the filename as the prompt name.
+
+### Handler Return Types
+
+| Return Type | Use Case |
+|-------------|----------|
+| `string` | Simple text prompt |
+| `{ type: "text", text: string }` | Explicit text content |
+| `{ type: "image", data: base64, mimeType: string }` | Image content |
+| `Array<Content>` | Multiple content blocks |
+
+## Use Cases for Server-Exposed Prompts
+
+MCP prompts are useful for:
+
+1. **Standardized workflows** - Consistent code review, documentation patterns
+2. **Complex templates** - Multi-step analysis prompts with structure
+3. **Domain expertise** - Specialized prompts for specific domains
+4. **Reusable patterns** - Common tasks that benefit from parameterization
+5. **Client integration** - Prompts that MCP clients can discover and use
+
+## Detailed Templates
+
+For complete code templates including:
+- Simple prompt patterns
+- Parameterized prompts with Zod schemas
+- Multi-role conversation prompts
+- Autocompletion support
+- Code review and documentation examples
+
+**Read: `references/patterns.md`**
+
+---
+
+## Checklist After Generation
+
+1. File created in `src/prompts/{prompt-name}.ts`
+2. If using metadata, ensure it has `name`, `title`, and `description`
+3. Schema uses `.describe()` for all parameters (if parameterized)
+4. Handler returns appropriate content format
+5. Role is set appropriately for the use case
+
+Suggest running `pnpm build` to verify the prompt compiles correctly.

--- a/apps/website/agent-skills/prompt-design/references/patterns.md
+++ b/apps/website/agent-skills/prompt-design/references/patterns.md
@@ -1,0 +1,380 @@
+# xmcp Prompt Templates Reference
+
+This file contains detailed code templates for creating xmcp prompts. Use these patterns when generating prompt code.
+
+---
+
+## Simple Prompt Templates
+
+### Template A: Basic Static Prompt
+
+Best for: Fixed prompts without parameters
+
+**File: `src/prompts/explain-code.ts`**
+
+```typescript
+import { type PromptMetadata } from "xmcp";
+
+export const metadata: PromptMetadata = {
+  name: "explain-code",
+  title: "Explain Code",
+  description: "Ask for a detailed explanation of code",
+  role: "user",
+};
+
+export default function handler() {
+  return `Please explain the following code in detail:
+- What does it do?
+- How does it work?
+- What are the key concepts involved?
+- Are there any potential issues or improvements?`;
+}
+```
+
+### Template B: Simple Text Return
+
+Best for: Prompts returning explicit content type
+
+```typescript
+import { type PromptMetadata } from "xmcp";
+
+export const metadata: PromptMetadata = {
+  name: "summarize",
+  title: "Summarize",
+  description: "Request a summary of content",
+  role: "user",
+};
+
+export default function handler() {
+  return {
+    type: "text",
+    text: "Please provide a concise summary of the above content, highlighting the key points and main takeaways.",
+  };
+}
+```
+
+### Minimal Prompt (No Metadata)
+
+Best for: Quick prototyping, simple prompts
+
+**File: `src/prompts/hello.ts`**
+
+```typescript
+// Metadata is optional - prompt name defaults to filename
+export default function handler() {
+  return "Hello! How can I help you today?";
+}
+```
+
+**Note:** When metadata is omitted, xmcp uses the filename as the prompt name.
+
+---
+
+## Parameterized Prompt Templates
+
+### Template C: Code Review Prompt
+
+Best for: Structured code analysis with customization
+
+**File: `src/prompts/review-code.ts`**
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type PromptMetadata } from "xmcp";
+
+export const schema = {
+  code: z.string().describe("The code to review"),
+  language: z.string().optional().describe("Programming language"),
+  focus: z.enum(["security", "performance", "readability", "all"])
+    .default("all")
+    .describe("Review focus area"),
+};
+
+export const metadata: PromptMetadata = {
+  name: "review-code",
+  title: "Review Code",
+  description: "Review code for best practices and potential issues",
+  role: "user",
+};
+
+export default function handler({
+  code,
+  language,
+  focus
+}: InferSchema<typeof schema>) {
+  const languageHint = language ? ` (${language})` : "";
+  const focusAreas = focus === "all"
+    ? "security, performance, and readability"
+    : focus;
+
+  return  `Please review this code${languageHint} focusing on ${focusAreas}:
+
+- Code quality and best practices
+- Potential bugs or issues
+- Suggestions for improvement
+
+Code to review:
+\`\`\`${language || ""}
+${code}
+\`\`\``
+}
+```
+
+### Template D: Documentation Generator Prompt
+
+Best for: Generating documentation from code
+
+**File: `src/prompts/generate-docs.ts`**
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type PromptMetadata } from "xmcp";
+
+export const schema = {
+  code: z.string().describe("The code to document"),
+  style: z.enum(["jsdoc", "markdown", "readme", "api"])
+    .default("jsdoc")
+    .describe("Documentation style"),
+  includeExamples: z.boolean()
+    .default(true)
+    .describe("Include usage examples"),
+};
+
+export const metadata: PromptMetadata = {
+  name: "generate-docs",
+  title: "Generate Documentation",
+  description: "Generate documentation for code",
+  role: "user",
+};
+
+export default function handler({
+  code,
+  style,
+  includeExamples
+}: InferSchema<typeof schema>) {
+  const styleGuide = {
+    jsdoc: "JSDoc comments with @param, @returns, and @example tags",
+    markdown: "Markdown documentation with headers and code blocks",
+    readme: "README.md format with installation, usage, and API sections",
+    api: "API reference documentation with endpoints and parameters",
+  };
+
+  return `Generate ${styleGuide[style]} for this code${includeExamples ? ", including usage examples" : ""}:
+
+\`\`\`
+${code}
+\`\`\`
+
+Please ensure the documentation is:
+- Clear and concise
+- Accurate to the code behavior
+- Properly formatted`;
+}
+```
+
+---
+
+## Autocompletion Support
+
+### Template E: Prompt with Autocompletion
+
+Best for: Prompts with known value sets
+
+**File: `src/prompts/team-greeting.ts`**
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type PromptMetadata, completable } from "xmcp";
+
+export const schema = {
+  department: completable(
+    z.string().describe("Department name"),
+    (value) => {
+      const departments = ["engineering", "sales", "marketing", "support"];
+      return departments.filter((d) => d.startsWith(value.toLowerCase()));
+    }
+  ),
+  name: completable(
+    z.string().describe("Team member name"),
+    (value, context) => {
+      const department = context?.arguments?.["department"];
+      const teams: Record<string, string[]> = {
+        engineering: ["Alice", "Bob", "Charlie"],
+        sales: ["David", "Eve", "Frank"],
+        marketing: ["Grace", "Henry", "Iris"],
+        support: ["Jack", "Kate", "Leo"],
+      };
+      const members = teams[department as string] || ["Guest"];
+      return members.filter((n) => n.toLowerCase().startsWith(value.toLowerCase()));
+    }
+  ),
+};
+
+export const metadata: PromptMetadata = {
+  name: "team-greeting",
+  title: "Team Greeting",
+  description: "Generate a personalized greeting for team members",
+  role: "assistant",
+};
+
+export default function handler({
+  department,
+  name
+}: InferSchema<typeof schema>) {
+  return `Hello ${name}! Welcome to the ${department} team. I'm here to help you with anything you need.`;
+}
+```
+
+---
+
+## Real-World Examples
+
+### Example: Pull Request Review
+
+**File: `src/prompts/review-pr.ts`**
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type PromptMetadata } from "xmcp";
+
+export const schema = {
+  diff: z.string().describe("The PR diff content"),
+  description: z.string().optional().describe("PR description"),
+  checkList: z.array(z.enum([
+    "security",
+    "performance",
+    "tests",
+    "documentation",
+    "breaking-changes"
+  ])).default(["security", "tests"]).describe("Review checklist items"),
+};
+
+export const metadata: PromptMetadata = {
+  name: "review-pr",
+  title: "Review Pull Request",
+  description: "Comprehensive pull request review",
+  role: "user",
+};
+
+export default function handler({
+  diff,
+  description,
+  checkList
+}: InferSchema<typeof schema>) {
+  const checks = checkList.map((item) => `- [ ] ${item}`).join("\n");
+
+  return `Please review this pull request.
+
+${description ? `**Description:** ${description}\n` : ""}
+**Review checklist:**
+${checks}
+
+**Diff:**
+\`\`\`diff
+${diff}
+\`\`\`
+
+Provide:
+1. Overall assessment
+2. Specific issues found (if any)
+3. Suggestions for improvement
+4. Approval recommendation (approve/request changes)`
+}
+```
+
+### Example: API Endpoint Documentation
+
+**File: `src/prompts/document-api.ts`**
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type PromptMetadata } from "xmcp";
+
+export const schema = {
+  endpoint: z.string().describe("API endpoint path"),
+  method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).describe("HTTP method"),
+  handler: z.string().describe("Handler code"),
+  includeOpenAPI: z.boolean().default(false).describe("Generate OpenAPI spec"),
+};
+
+export const metadata: PromptMetadata = {
+  name: "document-api",
+  title: "Document API Endpoint",
+  description: "Generate API documentation from endpoint handler",
+  role: "user",
+};
+
+export default function handler({
+  endpoint,
+  method,
+  handler,
+  includeOpenAPI
+}: InferSchema<typeof schema>) {
+  return `Generate documentation for this API endpoint:
+
+**Endpoint:** ${method} ${endpoint}
+
+**Handler code:**
+\`\`\`typescript
+${handler}
+\`\`\`
+
+Please document:
+1. Endpoint description
+2. Request parameters (path, query, body)
+3. Response format and status codes
+4. Example request/response
+${includeOpenAPI ? "5. OpenAPI 3.0 specification" : ""}`;
+}
+```
+
+---
+
+## Type Imports Reference
+
+```typescript
+// Basic prompt
+import { type PromptMetadata } from "xmcp";
+
+// Parameterized prompt
+import { z } from "zod";
+import { type InferSchema, type PromptMetadata } from "xmcp";
+```
+
+---
+
+## Best Practices
+
+### 1. Write Clear Descriptions
+```typescript
+// Good
+description: "Review code for security vulnerabilities, performance issues, and best practices"
+
+// Avoid
+description: "Reviews code"
+```
+
+### 2. Provide Parameter Defaults
+```typescript
+export const schema = {
+  format: z.enum(["detailed", "brief"]).default("detailed"),
+  includeExamples: z.boolean().default(true),
+};
+```
+
+### 3. Use Enums for Known Options
+```typescript
+export const schema = {
+  language: z.enum(["typescript", "javascript", "python", "go", "rust"]),
+  reviewType: z.enum(["security", "performance", "style", "comprehensive"]),
+};
+```
+
+### 4. Document Parameter Purpose
+```typescript
+export const schema = {
+  code: z.string().describe("Source code to analyze - can include multiple files"),
+  maxIssues: z.number().min(1).max(50).default(10)
+    .describe("Maximum number of issues to report"),
+};
+```

--- a/apps/website/agent-skills/resource-design/SKILL.md
+++ b/apps/website/agent-skills/resource-design/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: resource-design
+description: Design MCP resources to expose content for LLM consumption. Use when creating static or dynamic resources in xmcp.
+---
+
+# Create xmcp Resource
+
+You are helping the user create a new xmcp resource. Follow this interactive workflow.
+
+## Step 1: Gather Information
+
+Before generating any code, ask the user these questions using AskUserQuestion:
+
+1. **Resource name** (if not provided): What should the resource be named? (Use kebab-case)
+
+2. **Resource type**: Ask which type of resource they need:
+   - **Static** - Fixed content that doesn't change (configuration, documentation)
+   - **Dynamic** - Content that depends on parameters (user profiles, reports)
+   - **File-based** - Content read from files (logs, data files)
+
+3. **URI pattern**: How should the resource be accessed?
+   - Simple: `config://app` or `docs://readme`
+   - With parameters: `users://[userId]/profile`
+   - Nested: `reports://[year]/[month]/summary`
+
+4. **Content details**:
+   - What is the content about?
+
+5. **Widget support** (optional): Ask if they need OpenAI widget rendering.
+
+## Step 2: Generate the Resource
+
+Create the resource file in `src/resources/` following the routing conventions:
+
+### File Location & Routing
+
+Resources use file-based routing similar to Next.js:
+
+```
+src/resources/
+├── (config)/              # Route group (not in URI)
+│   └── app.ts            # → config://app
+├── (users)/
+│   └── [userId]/         # Dynamic segment
+│       └── profile.ts    # → users://[userId]/profile
+└── docs/
+    └── readme.ts         # → docs://readme
+```
+
+**Routing conventions:**
+- `(folder)` - Route group, excluded from URI path
+- `[param]` - Dynamic parameter segment
+- Filename becomes the final URI segment
+
+## Resource Structure Reference
+
+Every xmcp resource has two main exports:
+
+```typescript
+// 1. Metadata (optional) - Resource configuration
+export const metadata: ResourceMetadata = { /* ... */ };
+
+// 2. Handler (required) - Default export function
+export default function handler(params?) { /* ... */ }
+
+// 3. Schema (optional) - For dynamic resources with parameters
+export const schema = { /* ... */ };
+```
+
+## Quick Reference
+
+### Essential Imports
+```typescript
+import { type ResourceMetadata } from "xmcp";
+
+// For dynamic resources
+import { z } from "zod";
+import { type InferSchema, type ResourceMetadata } from "xmcp";
+```
+
+### Metadata Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | No* | Unique resource identifier |
+| `title` | string | No | Human-readable title |
+| `description` | string | No | What this resource provides |
+| `mimeType` | string | No | Content type (default: text/plain) |
+| `size` | number | No | Content size in bytes |
+| `_meta` | object | No | Vendor extensions (OpenAI, etc.) |
+
+*When metadata is omitted, xmcp uses the filename as the resource name.
+
+### Handler Return Types
+
+| Return Type | Use Case |
+|-------------|----------|
+| `string` | Simple text content |
+| `{ text: string }` | Explicit text content |
+| `{ blob: Uint8Array, mimeType: string }` | Binary content |
+| `JSON.stringify(data)` | JSON content |
+
+## Detailed Templates
+
+For complete code templates including:
+- Static resource patterns
+- Dynamic resource with parameters
+- File-based resources
+- Nested routing examples
+- OpenAI metadata examples
+
+**Read: `references/patterns.md`**
+
+---
+
+## Checklist After Generation
+
+1. File created in correct `src/resources/` location
+2. If using metadata, ensure it has descriptive `name` and `description`
+3. Schema uses `.describe()` for all parameters (if dynamic)
+4. Handler returns appropriate content type
+5. File path matches intended URI pattern
+
+Suggest running `pnpm build` to verify the resource compiles correctly.

--- a/apps/website/agent-skills/resource-design/references/patterns.md
+++ b/apps/website/agent-skills/resource-design/references/patterns.md
@@ -1,0 +1,369 @@
+# xmcp Resource Templates Reference
+
+This file contains detailed code templates for creating xmcp resources. Use these patterns when generating resource code.
+
+---
+
+## Static Resource Templates
+
+### Template A: Simple Static Resource
+
+Best for: Configuration, fixed content, documentation
+
+**File: `src/resources/(config)/app.ts`**
+**URI: `config://app`**
+
+```typescript
+import { type ResourceMetadata } from "xmcp";
+
+export const metadata: ResourceMetadata = {
+  name: "app-config",
+  title: "Application Configuration",
+  description: "Application configuration and settings",
+  mimeType: "application/json",
+};
+
+export default function handler() {
+  return JSON.stringify({
+    appName: "My Application",
+    version: "1.0.0",
+    features: {
+      darkMode: true,
+      notifications: true,
+    },
+  }, null, 2);
+}
+```
+
+### Minimal Resource (No Metadata)
+
+Best for: Quick prototyping, simple resources
+
+**File: `src/resources/(config)/settings.ts`**
+**URI: `config://settings`**
+
+```typescript
+// Metadata is optional - resource name defaults to filename
+export default function handler() {
+  return JSON.stringify({ theme: "dark", language: "en" });
+}
+```
+
+**Note:** When metadata is omitted, xmcp uses the filename as the resource name.
+
+---
+
+### Template B: Static Text Resource
+
+Best for: Documentation, README content, static text
+
+**File: `src/resources/docs/readme.ts`**
+**URI: `docs://readme`**
+
+```typescript
+import { type ResourceMetadata } from "xmcp";
+
+export const metadata: ResourceMetadata = {
+  name: "readme",
+  title: "README",
+  description: "Project documentation and getting started guide",
+  mimeType: "text/markdown",
+};
+
+export default function handler() {
+  return `# Project Documentation
+
+## Getting Started
+
+This is the project documentation...
+
+## Features
+
+- Feature 1
+- Feature 2
+- Feature 3
+`;
+}
+```
+
+---
+
+## Dynamic Resource Templates
+
+### Template C: Dynamic Resource with Single Parameter
+
+Best for: User profiles, single-item lookups
+
+**File: `src/resources/(users)/[userId]/profile.ts`**
+**URI: `users://[userId]/profile`**
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type ResourceMetadata } from "xmcp";
+
+export const schema = {
+  userId: z.string().describe("The unique identifier of the user"),
+};
+
+export const metadata: ResourceMetadata = {
+  name: "user-profile",
+  title: "User Profile",
+  description: "User profile information and preferences",
+  mimeType: "application/json",
+};
+
+export default async function handler({ userId }: InferSchema<typeof schema>) {
+  // Fetch user data from database or API
+  const user = await fetchUser(userId);
+
+  return JSON.stringify({
+    id: userId,
+    name: user.name,
+    email: user.email,
+    createdAt: user.createdAt,
+  }, null, 2);
+}
+```
+
+### Template D: Dynamic Resource with Multiple Parameters
+
+Best for: Nested lookups, time-scoped data
+
+**File: `src/resources/(reports)/[year]/[month]/summary.ts`**
+**URI: `reports://[year]/[month]/summary`**
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type ResourceMetadata } from "xmcp";
+
+export const schema = {
+  year: z.string().regex(/^\d{4}$/).describe("The year (YYYY format)"),
+  month: z.string().regex(/^\d{2}$/).describe("The month (MM format)"),
+};
+
+export const metadata: ResourceMetadata = {
+  name: "monthly-report",
+  title: "Monthly Report",
+  description: "Monthly summary report with key metrics",
+  mimeType: "application/json",
+};
+
+export default async function handler({
+  year,
+  month
+}: InferSchema<typeof schema>) {
+  const report = await generateReport(year, month);
+
+  return JSON.stringify({
+    period: `${year}-${month}`,
+    metrics: report.metrics,
+    summary: report.summary,
+    generatedAt: new Date().toISOString(),
+  }, null, 2);
+}
+```
+
+---
+
+## File-Based Resource Templates
+
+### Template E: File Content Resource
+
+Best for: Log files, data files, uploaded content
+
+**File: `src/resources/(files)/[filename]/content.ts`**
+**URI: `files://[filename]/content`**
+
+```typescript
+import { z } from "zod";
+import { readFile } from "fs/promises";
+import { type InferSchema, type ResourceMetadata } from "xmcp";
+
+export const schema = {
+  filename: z.string().describe("The name of the file to read"),
+};
+
+export const metadata: ResourceMetadata = {
+  name: "file-content",
+  title: "File Content",
+  description: "Read content from a file",
+  mimeType: "text/plain",
+};
+
+export default async function handler({
+  filename
+}: InferSchema<typeof schema>) {
+  const filepath = `/data/files/${filename}`;
+  const content = await readFile(filepath, "utf-8");
+  return content;
+}
+```
+
+### Template F: Binary File Resource
+
+Best for: Images, PDFs, binary data
+
+**File: `src/resources/(assets)/[assetId]/download.ts`**
+**URI: `assets://[assetId]/download`**
+
+```typescript
+import { z } from "zod";
+import { readFile } from "fs/promises";
+import { type InferSchema, type ResourceMetadata } from "xmcp";
+
+export const schema = {
+  assetId: z.string().describe("The asset identifier"),
+};
+
+export const metadata: ResourceMetadata = {
+  name: "asset-download",
+  title: "Asset Download",
+  description: "Download binary asset content",
+  mimeType: "application/octet-stream",
+};
+
+export default async function handler({
+  assetId
+}: InferSchema<typeof schema>) {
+  const asset = await getAsset(assetId);
+  const content = await readFile(asset.path);
+
+  return {
+    blob: new Uint8Array(content),
+    mimeType: asset.mimeType,
+  };
+}
+```
+
+---
+
+## Nested Routing Examples
+
+### Template G: Deeply Nested Resource
+
+**File: `src/resources/(api)/v1/[service]/[resource]/[id]/details.ts`**
+**URI: `api://v1/[service]/[resource]/[id]/details`**
+
+```typescript
+import { z } from "zod";
+import { type InferSchema, type ResourceMetadata } from "xmcp";
+
+export const schema = {
+  service: z.enum(["users", "orders", "products"]).describe("The service name"),
+  resource: z.string().describe("The resource type"),
+  id: z.string().describe("The resource identifier"),
+};
+
+export const metadata: ResourceMetadata = {
+  name: "api-resource-details",
+  title: "API Resource Details",
+  description: "Detailed information about an API resource",
+  mimeType: "application/json",
+};
+
+export default async function handler({
+  service,
+  resource,
+  id
+}: InferSchema<typeof schema>) {
+  const data = await fetchResourceDetails(service, resource, id);
+  return JSON.stringify(data, null, 2);
+}
+```
+
+---
+
+## Return Value Patterns
+
+### Text Content (Default)
+```typescript
+return "Plain text content";
+```
+
+### JSON Content
+```typescript
+// Formatted JSON
+return JSON.stringify(data, null, 2);
+
+// Compact JSON
+return JSON.stringify(data);
+```
+
+### Binary Content
+```typescript
+return {
+  blob: new Uint8Array(buffer),
+  mimeType: "image/png",
+};
+```
+
+---
+
+## Route Group Patterns
+
+Route groups `(folder)` organize resources without affecting the URI:
+
+```
+src/resources/
+├── (public)/           # Public resources
+│   ├── docs/
+│   │   └── api.ts     # → docs://api
+│   └── status.ts      # → status://
+├── (private)/          # Private/authenticated resources
+│   └── (users)/
+│       └── me/
+│           └── profile.ts  # → users://me/profile
+└── (admin)/            # Admin resources
+    └── config.ts      # → admin://config
+```
+
+---
+
+## Type Imports Reference
+
+```typescript
+// Core types
+import { type ResourceMetadata, type InferSchema } from "xmcp";
+
+// Zod for schemas
+import { z } from "zod";
+```
+
+---
+
+## Best Practices
+
+### 1. Use Descriptive Names
+```typescript
+// Good
+name: "user-preferences"
+description: "User preference settings including theme and notification options"
+
+// Avoid
+name: "prefs"
+description: "Preferences"
+```
+
+### 2. Validate Parameters with Zod
+```typescript
+export const schema = {
+  id: z.string().uuid().describe("UUID of the resource"),
+  limit: z.number().int().min(1).max(100).default(10).describe("Results limit"),
+  format: z.enum(["json", "csv", "xml"]).describe("Output format"),
+};
+```
+
+### 3. Handle Errors Gracefully
+```typescript
+export default async function handler({ id }: InferSchema<typeof schema>) {
+  try {
+    const data = await fetchData(id);
+    return JSON.stringify(data, null, 2);
+  } catch (error) {
+    return JSON.stringify({
+      error: "Failed to fetch resource",
+      message: error.message,
+    });
+  }
+}
+```

--- a/apps/website/agent-skills/widget-design/SKILL.md
+++ b/apps/website/agent-skills/widget-design/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: widget-design
+description: Best practices for designing UI widgets in xmcp. Use when creating interactive widgets for GPT Apps or MCP Apps, choosing between React components and template literals, designing widget layouts, handling state and data fetching, or troubleshooting widget rendering issues.
+---
+
+# Widget Design Best Practices
+
+## Decision Framework
+
+### Platform Selection
+
+Choose based on target client:
+
+- **GPT Apps**: Target is ChatGPT. Requires `_meta.openai` with `widgetAccessible: true`.
+- **MCP Apps**: Target is any ext-apps client. Minimal config, works automatically.
+
+### Handler Type Selection
+
+| Scenario | Handler | Reason |
+|----------|---------|--------|
+| User interaction needed (buttons, inputs) | React (`.tsx`) | State management with hooks |
+| Display external widget library | Template literal | Just load scripts/styles |
+| Dynamic content from tool params | React | Props flow naturally |
+| Static HTML with no state | Template literal | Simpler, less overhead |
+
+**Rule of thumb**: If unsure, start with React. Converting later is harder than starting simple.
+
+## Widget Design Principles
+
+### 1. Widgets Are Not Web Apps
+
+Widgets render inline in conversations. Design constraints:
+
+- **No navigation**: Single-screen experience only
+- **Limited width**: ~600-700px max in most clients
+- **Sandboxed**: External resources need CSP declarations
+- **Ephemeral**: May be re-rendered, don't rely on persistence
+
+### 2. Immediate Value
+
+Show useful content without requiring user action:
+
+```tsx
+// Bad: Requires click to see anything
+export default function Widget() {
+  const [data, setData] = useState(null);
+  return <button onClick={fetchData}>Load Data</button>;
+}
+
+// Good: Shows data immediately
+export default function Widget({ query }) {
+  const [data, setData] = useState(null);
+  useEffect(() => { fetchData(query).then(setData); }, [query]);
+  return data ? <Results data={data} /> : <Loading />;
+}
+```
+
+### 3. Visual Hierarchy in Limited Space
+
+With limited width, hierarchy matters more:
+
+```tsx
+<div className="space-y-4">
+  {/* Label: small, muted, uppercase */}
+  <div className="text-sm text-zinc-500 uppercase tracking-wider">Temperature</div>
+  
+  {/* Value: large, prominent */}
+  <div className="text-5xl font-light">72°F</div>
+  
+  {/* Supporting: medium, secondary */}
+  <div className="text-zinc-400">Feels like 68°F</div>
+</div>
+```
+
+### 4. Every Interactive Element Needs Feedback
+
+Users need visual confirmation that elements are interactive:
+
+```tsx
+// Bad: No visual feedback
+<button className="px-4 py-2 bg-white/10">Click</button>
+
+// Good: Hover + transition
+<button className="px-4 py-2 bg-white/10 hover:bg-white/20 border border-white/10 hover:border-white/20 transition-all duration-200">
+  Click
+</button>
+```
+
+## State Management Guidelines
+
+### Keep State Local and Simple
+
+Widgets are isolated. No Redux, Zustand, or external state.
+
+```tsx
+// Good: Local state with hooks
+const [items, setItems] = useState([]);
+const [loading, setLoading] = useState(true);
+const [error, setError] = useState(null);
+```
+
+### Always Handle Three States
+
+Every async operation has three states. Handle all of them:
+
+```tsx
+export default function Widget() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchData()
+      .then(setData)
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <Loading />;
+  if (error) return <Error message={error} />;
+  return <Display data={data} />;
+}
+```
+
+### Fetch on Mount, Not on Click
+
+Widgets should show value immediately:
+
+```tsx
+// Bad: User must click to see data
+<button onClick={() => fetchData()}>Load</button>
+
+// Good: Fetch automatically
+useEffect(() => { fetchData(); }, []);
+```
+
+## Common Mistakes
+
+### 1. Missing widgetAccessible (GPT Apps)
+
+Widget won't render without this:
+
+```typescript
+// Broken
+_meta: { openai: { toolInvocation: { ... } } }
+
+// Fixed
+_meta: { openai: { widgetAccessible: true, toolInvocation: { ... } } }
+```
+
+### 2. External Fetch Without CSP
+
+Requests blocked silently:
+
+```typescript
+// Broken: fetch fails silently
+fetch('{{WEATHER_API_URL}}');
+
+// Fixed: declare in metadata
+_meta: {
+  openai: {
+    widgetCSP: { connect_domains: ["{{WEATHER_API_BASE_URL}}"] }
+  }
+}
+```
+
+### 3. Hardcoded Dimensions
+
+Widgets break on different screen sizes:
+
+```tsx
+// Bad
+<div style={{ width: '800px' }}>...</div>
+
+// Good
+<div className="w-full max-w-2xl mx-auto">...</div>
+```
+
+### 4. No Error Boundaries
+
+Crashes show blank widget:
+
+```tsx
+// Always wrap risky operations
+try {
+  const result = JSON.parse(data);
+} catch {
+  return <Error message="Invalid data format" />;
+}
+```
+
+## Platform-Specific Notes
+
+### GPT Apps: Structured Content for Widget Communication
+
+Pass data from tool to widget:
+
+```typescript
+return {
+  structuredContent: { game: "doom", url: "..." },
+  content: [{ type: "text", text: "Launching DOOM..." }],
+};
+```
+
+Widget reads via `useToolOutput()` hook.
+
+### MCP Apps: Minimal Config
+
+MCP Apps work with just a React component:
+
+```tsx
+// This is enough for MCP Apps
+export const metadata = { name: "widget", description: "..." };
+export default function Widget() { return <div>Hello</div>; }
+```
+
+## Quick Reference
+
+### GPT Apps Checklist
+- `widgetAccessible: true` in metadata
+- `toolInvocation` messages under 64 chars
+- CSP for external domains
+
+## References
+
+See [references/design-principles.md](references/design-principles.md) for:
+- Complete widget examples (counter, weather, arcade)
+- Component patterns (cards, buttons, tabs)
+- CSS Modules examples
+- GPT App submission requirements
+- Project structure templates

--- a/apps/website/agent-skills/widget-design/references/design-principles.md
+++ b/apps/website/agent-skills/widget-design/references/design-principles.md
@@ -1,0 +1,539 @@
+# Widget Design Principles
+
+Extended reference for widget design in xmcp. Load this file when working with complex widgets, GPT App submissions, or advanced patterns.
+
+## Table of Contents
+
+1. [Complete Widget Examples](#complete-widget-examples)
+2. [Component Patterns](#component-patterns)
+3. [Widget-to-Tool Communication](#widget-to-tool-communication)
+4. [Anti-Patterns](#anti-patterns)
+5. [GPT App Submission](#gpt-app-submission)
+6. [Project Structures](#project-structures)
+
+---
+
+## Complete Widget Examples
+
+### GPT App: Counter with Tailwind
+
+```tsx
+// src/tools/counter.tsx
+import { InferSchema, type ToolMetadata } from "xmcp";
+import { useState } from "react";
+import { z } from "zod";
+
+export const metadata: ToolMetadata = {
+  name: "counter",
+  description: "Interactive counter widget",
+  _meta: {
+    openai: {
+      toolInvocation: {
+        invoking: "Loading counter",
+        invoked: "Counter loaded",
+      },
+      widgetAccessible: true,
+      resultCanProduceWidget: true,
+    },
+  },
+};
+
+export const schema = {
+  initialCount: z.number().describe("The initial count value"),
+};
+
+export default function handler({ initialCount }: InferSchema<typeof schema>) {
+  const [count, setCount] = useState(initialCount);
+
+  return (
+    <div className="min-h-screen bg-black text-white flex items-center justify-center p-8">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-16">
+          <div className="text-sm font-mono text-zinc-500 uppercase tracking-wider mb-4">
+            Counter
+          </div>
+          <div className="text-8xl font-light tracking-tight mb-2">{count}</div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <button
+              onClick={() => setCount(count - 1)}
+              className="px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 transition-all duration-200 text-sm font-mono uppercase tracking-wider"
+            >
+              Decrement
+            </button>
+            <button
+              onClick={() => setCount(count + 1)}
+              className="px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 transition-all duration-200 text-sm font-mono uppercase tracking-wider"
+            >
+              Increment
+            </button>
+          </div>
+          <button
+            onClick={() => setCount(0)}
+            className="w-full px-8 py-4 bg-white text-black hover:bg-zinc-200 transition-all duration-200 text-sm font-mono uppercase tracking-wider"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+### GPT App: Weather with External API
+
+```tsx
+// src/tools/weather.tsx
+import { type ToolMetadata } from "xmcp";
+import { useState, useEffect } from "react";
+
+export const metadata: ToolMetadata = {
+  name: "weather",
+  description: "Weather App",
+  _meta: {
+    openai: {
+      toolInvocation: {
+        invoking: "Loading weather",
+        invoked: "Weather loaded",
+      },
+      widgetAccessible: true,
+      resultCanProduceWidget: true,
+      widgetCSP: {
+        connect_domains: ["{{WEATHER_API_BASE_URL}}"],
+      },
+    },
+  },
+};
+
+const cities = {
+  "Buenos Aires": { lat: -34.6037, lon: -58.3816 },
+  "San Francisco": { lat: 37.7749, lon: -122.4194 },
+  "Tokyo": { lat: 35.6762, lon: 139.6503 },
+};
+const WEATHER_API_BASE_URL = "{{WEATHER_API_BASE_URL}}";
+
+export default function handler() {
+  const [selectedCity, setSelectedCity] = useState("Buenos Aires");
+  const [weatherData, setWeatherData] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchWeather = async () => {
+      setLoading(true);
+      setError(null);
+      const city = cities[selectedCity as keyof typeof cities];
+      try {
+        const response = await fetch(
+          `${WEATHER_API_BASE_URL}/v1/forecast?latitude=${city.lat}&longitude=${city.lon}&current=temperature_2m,relative_humidity_2m,wind_speed_10m`
+        );
+        if (!response.ok) throw new Error("Failed to fetch");
+        setWeatherData(await response.json());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchWeather();
+  }, [selectedCity]);
+
+  return (
+    <div className="min-h-screen bg-black text-white p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-5xl font-light text-center mb-12">{selectedCity}</h1>
+        <div className="flex flex-wrap justify-center gap-3 mb-16">
+          {Object.keys(cities).map((city) => (
+            <button
+              key={city}
+              onClick={() => setSelectedCity(city)}
+              className={`px-6 py-3 text-sm font-mono uppercase transition-all ${
+                selectedCity === city
+                  ? "bg-white text-black"
+                  : "bg-white/5 hover:bg-white/10 border border-white/10"
+              }`}
+            >
+              {city}
+            </button>
+          ))}
+        </div>
+        {loading && <div className="text-center text-zinc-500">Loading...</div>}
+        {error && <div className="text-center text-red-400">Error: {error}</div>}
+        {weatherData && !loading && (
+          <div className="grid grid-cols-3 gap-6">
+            <Card label="Temperature" value={`${weatherData.current.temperature_2m}deg`} />
+            <Card label="Humidity" value={`${weatherData.current.relative_humidity_2m}%`} />
+            <Card label="Wind" value={`${weatherData.current.wind_speed_10m} km/h`} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Card({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border border-white/10 bg-white/5 p-8">
+      <div className="text-sm text-zinc-500 uppercase mb-4">{label}</div>
+      <div className="text-5xl font-light">{value}</div>
+    </div>
+  );
+}
+```
+
+### GPT App: Template Literal Resource
+
+```typescript
+// src/resources/(ui)/widget/pizza-map.ts
+import { type ResourceMetadata } from "xmcp";
+
+export const metadata: ResourceMetadata = {
+  name: "pizza-map",
+  title: "Show Pizza Map",
+  mimeType: "text/html+skybridge",
+};
+
+export default async function handler() {
+  return `
+    <div id="pizzaz-root"></div>
+    <link rel="stylesheet" href="{{PIZZAZ_CSS_URL}}">
+    <script type="module" src="{{PIZZAZ_JS_URL}}"></script>
+  `.trim();
+}
+```
+
+### GPT App: CSS Modules
+
+```css
+/* counter.module.css */
+.container {
+  min-height: 100vh;
+  background-color: black;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.count {
+  font-size: 6rem;
+  font-weight: 300;
+}
+
+.button {
+  padding: 1rem 2rem;
+  background-color: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: white;
+  cursor: pointer;
+  transition: all 200ms;
+}
+
+.button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+```
+
+```tsx
+// counter.tsx
+import styles from "./counter.module.css";
+
+export default function Counter({ initialCount }) {
+  const [count, setCount] = useState(initialCount);
+  return (
+    <div className={styles.container}>
+      <div className={styles.count}>{count}</div>
+      <button className={styles.button} onClick={() => setCount(count + 1)}>+</button>
+    </div>
+  );
+}
+```
+
+### MCP App: Minimal Widget
+
+```tsx
+// src/tools/greeting.tsx
+import { type ToolMetadata, type InferSchema } from "xmcp";
+import { z } from "zod";
+
+export const metadata: ToolMetadata = {
+  name: "greeting",
+  description: "Display a greeting",
+};
+
+export const schema = {
+  name: z.string().describe("Name to greet"),
+};
+
+export default function Greeting({ name }: InferSchema<typeof schema>) {
+  return (
+    <div className="min-h-screen bg-black text-white flex items-center justify-center">
+      <h1 className="text-6xl font-light">Hello, {name}!</h1>
+    </div>
+  );
+}
+```
+
+---
+
+## Component Patterns
+
+### Card
+
+```tsx
+function Card({ label, value, unit }: { label: string; value: string | number; unit?: string }) {
+  return (
+    <div className="border border-white/10 bg-white/5 p-8 hover:border-white/20 transition-all">
+      <div className="text-sm font-mono text-zinc-500 uppercase tracking-wider mb-4">{label}</div>
+      <div className="text-5xl font-light tracking-tight">
+        {value}
+        {unit && <span className="text-2xl text-zinc-500 ml-2">{unit}</span>}
+      </div>
+    </div>
+  );
+}
+```
+
+### Button Variants
+
+```tsx
+// Primary
+<button className="w-full px-8 py-4 bg-white text-black hover:bg-zinc-200 transition-all text-sm font-mono uppercase">
+  Primary
+</button>
+
+// Secondary
+<button className="px-8 py-4 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 transition-all text-sm font-mono uppercase">
+  Secondary
+</button>
+
+// Tab
+<button className={`px-6 py-3 text-sm font-mono uppercase transition-all ${
+  isSelected ? "bg-white text-black" : "bg-white/5 hover:bg-white/10 border border-white/10"
+}`}>
+  Tab
+</button>
+```
+
+### Loading & Error
+
+```tsx
+function Loading() {
+  return <div className="text-center text-zinc-500 font-mono text-sm">Loading...</div>;
+}
+
+function ErrorMessage({ message }: { message: string }) {
+  return (
+    <div className="text-center text-red-400 font-mono text-sm border border-red-400/20 bg-red-400/5 py-4 px-6">
+      Error: {message}
+    </div>
+  );
+}
+```
+
+---
+
+## Widget-to-Tool Communication
+
+GPT Apps support bidirectional communication using hooks.
+
+### Hooks
+
+```tsx
+import { useCallTool } from "@/hooks/use-call-tool";
+import { useToolOutput } from "@/hooks/use-tool-output";
+
+// Call tool from widget
+const callTool = useCallTool();
+await callTool("launch_game", { game: "doom" });
+
+// Access structured content
+const output = useToolOutput<GameStructuredContent>();
+if (output?.game) {
+  // Game launched
+}
+```
+
+### Structured Content Response
+
+```typescript
+export default async function handler({ game }: InferSchema<typeof schema>) {
+  return {
+    structuredContent: {
+      game: "doom",
+      title: "DOOM",
+      url: "{{GAME_ASSET_URL}}",
+    },
+    content: [{ type: "text", text: "Launching DOOM..." }],
+  };
+}
+```
+
+### Interactive Card Example
+
+```tsx
+function GameCard({ name }: { name: string }) {
+  const callTool = useCallTool();
+
+  return (
+    <button onClick={() => callTool("launch_game", { game: name })}>
+      <h3>{name}</h3>
+    </button>
+  );
+}
+```
+
+---
+
+## Anti-Patterns
+
+### Missing widgetAccessible (GPT Apps)
+
+```typescript
+// Bad - widget won't render
+_meta: { openai: { toolInvocation: { invoking: "...", invoked: "..." } } }
+
+// Good
+_meta: { openai: { widgetAccessible: true, toolInvocation: { ... } } }
+```
+
+### Wrong MIME Type
+
+```typescript
+// Bad
+mimeType: "text/html"
+
+// Good
+mimeType: "text/html+skybridge"
+```
+
+### Missing CSP
+
+```typescript
+// Bad - fetch blocked
+fetch('{{EXTERNAL_API_URL}}');
+
+// Good - declare in metadata
+widgetCSP: { connect_domains: ["{{EXTERNAL_API_BASE_URL}}"] }
+```
+
+### No Loading State
+
+```tsx
+// Bad - crashes on null
+return <div>{data.value}</div>;
+
+// Good
+if (loading) return <Loading />;
+if (error) return <Error message={error} />;
+return <div>{data.value}</div>;
+```
+
+### Hardcoded Dimensions
+
+```tsx
+// Bad
+style={{ width: '800px' }}
+
+// Good
+className="w-full max-w-4xl mx-auto"
+```
+
+### Missing Hover States
+
+```tsx
+// Bad
+className="bg-white/10"
+
+// Good
+className="bg-white/10 hover:bg-white/20 transition-all"
+```
+
+---
+
+## GPT App Submission
+
+### Required Assets
+
+- **Icon**: SVG 64x64px (test in dark mode)
+- **Demo video**: Same domain as app
+- **Legal**: Privacy policy and terms of service
+- **Screenshots**: Width 706px, height 400-860px (up to 4)
+
+### Domain Verification
+
+Serve token at `/.well-known/openai-apps-challenge`
+
+xmcp standalone: Set `OPENAI-APPS-VERIFICATION-TOKEN` env var (auto-handled)
+
+### Tool Annotations
+
+```typescript
+annotations: {
+  readOnlyHint: true,      // Only reads data
+  openWorldHint: true,     // Web access / external calls
+  destructiveHint: false,  // Modifies/deletes data
+}
+```
+
+### Test Cases
+
+Positive (tool should trigger):
+- Scenario, User prompt, Tool triggered, Expected output
+
+Negative (tool should NOT trigger):
+- Scenario, User prompt
+
+Use [MCPJam](https://www.mcpjam.com/) to auto-generate test cases.
+
+---
+
+## Project Structures
+
+### GPT App
+
+```
+my-gpt-app/
+|-- src/
+|   |-- tools/
+|   |   |-- counter.tsx
+|   |   |-- counter.module.css
+|   |-- resources/
+|   |   |-- (ui)/widget/custom.ts
+|   |-- globals.css
+|-- postcss.config.mjs
+|-- xmcp.config.ts
+```
+
+### MCP App
+
+```
+my-mcp-app/
+|-- src/
+|   |-- tools/
+|   |   |-- counter.tsx
+|   |-- globals.css
+|-- xmcp.config.ts
+```
+
+### GPT App with Next.js
+
+```
+arcade/
+|-- xmcp/                    # MCP Server
+|   |-- src/tools/
+|   |   |-- arcade.ts
+|   |   |-- launch-game.ts
+|   |-- xmcp.config.ts
+|-- application/             # Next.js
+    |-- app/widgets/
+    |   |-- arcade/page.tsx
+    |-- hooks/
+        |-- use-call-tool.ts
+        |-- use-tool-output.ts
+```

--- a/apps/website/app/.well-known/agent-skills/[...path]/route.ts
+++ b/apps/website/app/.well-known/agent-skills/[...path]/route.ts
@@ -1,0 +1,29 @@
+import { notFound } from "next/navigation";
+import { listSkillFiles, readSkillFile } from "@/lib/agent-skills";
+
+// Serves each skill's SKILL.md and references/* so the relative links inside a
+// SKILL.md resolve. The sibling `index.json` static segment takes precedence
+// over this catch-all. Prerendered from the committed skill files.
+export const dynamic = "force-static";
+export const revalidate = false;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const content = readSkillFile(path);
+  if (content === null) notFound();
+
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, must-revalidate",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+export function generateStaticParams() {
+  return listSkillFiles().map((segments) => ({ path: segments }));
+}

--- a/apps/website/app/.well-known/agent-skills/index.json/route.ts
+++ b/apps/website/app/.well-known/agent-skills/index.json/route.ts
@@ -1,0 +1,30 @@
+import { digest, listSkills, readSkillMarkdown } from "@/lib/agent-skills";
+
+/** Schema identifier for the Agent Skills Discovery RFC v0.2.0 index. */
+const SCHEMA_URL = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+
+// Fully derived from committed skill files, so it can be prerendered.
+export const dynamic = "force-static";
+export const revalidate = false;
+
+export function GET() {
+  const skills = listSkills().map((skill) => ({
+    name: skill.name,
+    type: "skill-md" as const,
+    // Path-absolute per RFC 3986 §5 — resolves against the index URL, so it
+    // works the same on production, previews, and localhost.
+    url: `/.well-known/agent-skills/${skill.dir}/SKILL.md`,
+    description: skill.description,
+    digest: digest(readSkillMarkdown(skill.dir)),
+  }));
+
+  return Response.json(
+    { $schema: SCHEMA_URL, skills },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=3600, must-revalidate",
+        "Access-Control-Allow-Origin": "*",
+      },
+    }
+  );
+}

--- a/apps/website/lib/agent-skills.ts
+++ b/apps/website/lib/agent-skills.ts
@@ -1,0 +1,115 @@
+import fs from "fs";
+import path from "path";
+import { createHash } from "crypto";
+
+/**
+ * Root of the published Agent Skills, served under
+ * `/.well-known/agent-skills/`. Each subdirectory is one skill with a
+ * `SKILL.md` and optional `references/` files. These are read at build time
+ * (the routes are `force-static`), so content is baked into the static output
+ * and the index digests can never drift from the bytes that get served.
+ */
+const SKILLS_ROOT = path.join(process.cwd(), "agent-skills");
+
+/** Extensions exposed over HTTP. Skills are markdown only. */
+const SERVABLE_EXTENSIONS = new Set([".md"]);
+
+export interface AgentSkill {
+  /** Published skill name; also the URL path segment. */
+  name: string;
+  /** Mirrors the `description` in the skill's SKILL.md frontmatter. */
+  description: string;
+  /** Directory name under {@link SKILLS_ROOT}. */
+  dir: string;
+}
+
+/** Read a single-line value for `key` out of YAML frontmatter. */
+function frontmatterValue(source: string, key: string): string | undefined {
+  const block = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!block) return undefined;
+  for (const line of block[1].split(/\r?\n/)) {
+    // Only top-level keys (no leading whitespace) so nested `metadata:` fields
+    // are ignored.
+    const field = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (field && field[1] === key) {
+      return field[2].trim().replace(/^["']|["']$/g, "");
+    }
+  }
+  return undefined;
+}
+
+/** Every published skill, derived from the directories under SKILLS_ROOT. */
+export function listSkills(): AgentSkill[] {
+  return fs
+    .readdirSync(SKILLS_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const dir = entry.name;
+      const source = fs.readFileSync(
+        path.join(SKILLS_ROOT, dir, "SKILL.md"),
+        "utf8"
+      );
+      return {
+        dir,
+        name: frontmatterValue(source, "name") ?? dir,
+        description: frontmatterValue(source, "description") ?? "",
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** `sha256:{hex}` content digest, per the Agent Skills Discovery RFC. */
+export function digest(bytes: Buffer): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+/** Raw bytes of a skill's SKILL.md — used for both serving and digesting. */
+export function readSkillMarkdown(dir: string): Buffer {
+  return fs.readFileSync(path.join(SKILLS_ROOT, dir, "SKILL.md"));
+}
+
+/**
+ * Resolve URL `segments` (the path after `/.well-known/agent-skills/`) to a
+ * skill file's raw bytes, or `null` if the path escapes SKILLS_ROOT, isn't a
+ * markdown file, or doesn't exist. Guards against path traversal.
+ */
+export function readSkillFile(segments: string[]): string | null {
+  if (segments.length === 0) return null;
+  const target = path.resolve(SKILLS_ROOT, ...segments);
+  const root = path.resolve(SKILLS_ROOT);
+  if (target !== root && !target.startsWith(root + path.sep)) return null;
+  if (!SERVABLE_EXTENSIONS.has(path.extname(target))) return null;
+  try {
+    if (!fs.statSync(target).isFile()) return null;
+    // Skills are utf8 markdown; serving the decoded text round-trips to the
+    // same bytes, so the index digest (over raw bytes) still matches.
+    return fs.readFileSync(target, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Every servable file path (as URL segments) across all skills, e.g.
+ * `["mcp-server-design", "SKILL.md"]` and
+ * `["mcp-server-design", "references", "design-principles.md"]`. Used to
+ * prerender the catch-all route via `generateStaticParams`.
+ */
+export function listSkillFiles(): string[][] {
+  const files: string[][] = [];
+  for (const skill of listSkills()) {
+    walk(path.join(SKILLS_ROOT, skill.dir), [skill.dir], files);
+  }
+  return files;
+}
+
+function walk(absDir: string, prefix: string[], out: string[][]): void {
+  for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+    const next = [...prefix, entry.name];
+    if (entry.isDirectory()) {
+      walk(path.join(absDir, entry.name), next, out);
+    } else if (SERVABLE_EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(next);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `/.well-known/agent-skills/index.json` per the Agent Skills Discovery RFC v0.2.0, resolving the "Agent Skills index not found" finding from isitagentready.com.
- Publishes five xmcp skills: `mcp-server-design`, `prompt-design`, `resource-design`, `create-tool`, `widget-design` with sha256 content digests.
- Each skill's `references/` files are served via a catch-all route so relative links inside `SKILL.md` resolve correctly.
- Both routes are force-static.

## Test plan

- [ ] `pnpm --filter website build` — confirm no build errors
- [ ] Deploy preview → `curl https://<preview>/.well-known/agent-skills/index.json` — confirm index returns all five skills with valid digests
- [ ] Check isitagentready.com against the preview URL — confirm `checks.discovery.agentSkillsIndex.status === "pass"`