### PR TITLE
fix(scalekit): accept both issuers and use RFC 8414 JWKS

### DIFF
--- a/apps/website/content/docs/integrations/scalekit.mdx
+++ b/apps/website/content/docs/integrations/scalekit.mdx
@@ -210,8 +210,8 @@ If you see `Session not initialized` errors:
 If token verification fails with network errors:
 
 - Verify `SCALEKIT_ENVIRONMENT_URL` is correct and reachable.
-- The plugin auto-discovers JWKS keys from the OIDC configuration endpoint.
-- Check that your server can reach `{environmentUrl}/.well-known/openid-configuration`.
+- The plugin discovers `jwks_uri` from Scalekit's RFC 8414 metadata at `{environmentUrl}/.well-known/oauth-authorization-server` (or `{environmentUrl}/.well-known/oauth-authorization-server/resources/{resourceId}` when `resourceId` is set), then falls back to `{environmentUrl}/keys`.
+- Check that your server can reach that metadata URL and `{environmentUrl}/keys`.
 
 ### Invalid Token Errors
 

--- a/examples/scalekit-http/README.md
+++ b/examples/scalekit-http/README.md
@@ -38,5 +38,6 @@ pnpm dev
 
 The server exposes:
 
-- `GET /.well-known/oauth-protected-resource` — Resource metadata for MCP clients
-- `GET /.well-known/oauth-authorization-server` — Proxied authorization server metadata from Scalekit
+- `GET /.well-known/oauth-protected-resource` — Resource metadata for MCP clients (`authorization_servers` points at Scalekit)
+
+Authorization server metadata (RFC 8414) is served by Scalekit, not this server. Clients follow `authorization_servers` from the protected resource metadata.

--- a/packages/plugins/scalekit/README.md
+++ b/packages/plugins/scalekit/README.md
@@ -129,6 +129,12 @@ export default async function myTool() {
 - MCP clients automatically refresh tokens using refresh tokens
 - If you see "token_expired" errors, the client should handle refresh automatically
 
+## OAuth metadata
+
+The plugin serves protected resource metadata at `GET /.well-known/oauth-protected-resource`. Clients follow `authorization_servers` to Scalekit for RFC 8414 authorization server metadata. The MCP server does not host `/.well-known/oauth-authorization-server`.
+
+During Scalekit's issuer migration, token verification accepts both the environment URL and, when `resourceId` is set, `https://<env>/resources/<resourceId>`.
+
 ## Example
 
 See the [`scalekit-http` example](https://github.com/basementstudio/xmcp/tree/canary/examples/scalekit-http) for a complete working project.

--- a/packages/plugins/scalekit/src/jwt.ts
+++ b/packages/plugins/scalekit/src/jwt.ts
@@ -8,14 +8,14 @@ export type TokenVerifyResult =
 export async function verifyScalekitToken(
   token: string,
   jwksUrl: URL,
-  issuer: string,
+  issuer: string | readonly string[],
   audience?: string
 ): Promise<TokenVerifyResult> {
   try {
     const JWKS = createRemoteJWKSet(jwksUrl);
 
     const verifyOptions: Record<string, unknown> = {
-      issuer,
+      issuer: typeof issuer === "string" ? issuer : [...issuer],
       clockTolerance: 30,
     };
     if (audience) {

--- a/packages/plugins/scalekit/src/jwt.ts
+++ b/packages/plugins/scalekit/src/jwt.ts
@@ -1,4 +1,4 @@
-import { createRemoteJWKSet, jwtVerify, errors } from "jose";
+import { jwtVerify, errors, type JWTVerifyGetKey } from "jose";
 import type { JWTClaims, Session } from "./types.js";
 
 export type TokenVerifyResult =
@@ -7,13 +7,11 @@ export type TokenVerifyResult =
 
 export async function verifyScalekitToken(
   token: string,
-  jwksUrl: URL,
+  keySet: JWTVerifyGetKey,
   issuer: string | readonly string[],
   audience?: string
 ): Promise<TokenVerifyResult> {
   try {
-    const JWKS = createRemoteJWKSet(jwksUrl);
-
     const verifyOptions: Record<string, unknown> = {
       issuer: typeof issuer === "string" ? issuer : [...issuer],
       clockTolerance: 30,
@@ -22,7 +20,7 @@ export async function verifyScalekitToken(
       verifyOptions.audience = audience;
     }
 
-    const { payload } = await jwtVerify(token, JWKS, verifyOptions);
+    const { payload } = await jwtVerify(token, keySet, verifyOptions);
 
     if (!payload.sub) {
       console.error("[Scalekit] Missing required JWT claim: sub");

--- a/packages/plugins/scalekit/src/provider.ts
+++ b/packages/plugins/scalekit/src/provider.ts
@@ -18,6 +18,7 @@ import {
   extractBearerToken,
 } from "./jwt.js";
 import { Scalekit } from "@scalekit-sdk/node";
+import { createRemoteJWKSet, type JWTVerifyGetKey } from "jose";
 
 export function scalekitProvider(config: Config): Middleware {
   if (!config.environmentUrl) {
@@ -139,22 +140,36 @@ function scalekitMiddleware(config: Config): RequestHandler {
   const authServerBase = getAuthServerBase(config);
   const expectedIssuers = getExpectedIssuers(config);
 
-  // Pre-fetch JWKS URI from OIDC discovery
-  let resolvedJwksUri: URL | null = null;
-  (async () => {
-    try {
-      const oidcUrl = `${authServerBase}/.well-known/openid-configuration`;
-      const response = await fetch(oidcUrl);
-      if (response.ok) {
-        const oidcConfig = (await response.json()) as { jwks_uri?: string };
-        if (oidcConfig.jwks_uri) {
-          resolvedJwksUri = new URL(oidcConfig.jwks_uri);
+  // Resolve the JWKS once and cache the remote key set for the lifetime of the
+  // middleware. createRemoteJWKSet maintains its own key cache, so building it
+  // per request would defeat that and refetch the JWKS on every verification.
+  let jwks: Promise<JWTVerifyGetKey> | null = null;
+  const getJwks = (): Promise<JWTVerifyGetKey> => {
+    if (!jwks) {
+      jwks = (async () => {
+        let jwksUri = new URL(`${authServerBase}/keys`);
+        try {
+          const oidcUrl = `${authServerBase}/.well-known/openid-configuration`;
+          const response = await fetch(oidcUrl);
+          if (response.ok) {
+            const oidcConfig = (await response.json()) as { jwks_uri?: string };
+            if (oidcConfig.jwks_uri) {
+              jwksUri = new URL(oidcConfig.jwks_uri);
+            }
+          }
+        } catch {
+          // Fall back to the constructed key set URL
         }
-      }
-    } catch {
-      // Will fall back to constructed URL at request time
+        return createRemoteJWKSet(jwksUri);
+      })().catch((error) => {
+        // Don't cache a rejected promise, otherwise a transient discovery
+        // error would wedge the middleware for its whole lifetime.
+        jwks = null;
+        throw error;
+      });
     }
-  })();
+    return jwks;
+  };
 
   return async (req: Request, res: Response, next: NextFunction) => {
     if (!req.path.startsWith("/mcp")) {
@@ -177,14 +192,13 @@ function scalekitMiddleware(config: Config): RequestHandler {
         return;
       }
 
-      const jwksUrl =
-        resolvedJwksUri || new URL(`${authServerBase}/keys`);
+      const keySet = await getJwks();
       const audience =
         config.resourceId || config.baseURL.replace(/\/$/, "");
 
       const result = await verifyScalekitToken(
         token,
-        jwksUrl,
+        keySet,
         expectedIssuers,
         audience
       );

--- a/packages/plugins/scalekit/src/provider.ts
+++ b/packages/plugins/scalekit/src/provider.ts
@@ -137,8 +137,15 @@ function scalekitRouter(config: Config): Router {
 }
 
 function scalekitMiddleware(config: Config): RequestHandler {
-  const authServerBase = getAuthServerBase(config);
   const expectedIssuers = getExpectedIssuers(config);
+
+  // JWKS and OIDC discovery live at the environment root, NOT under the
+  // resource-scoped issuer that getAuthServerBase() returns. Scalekit serves the
+  // key set at `${env}/keys` (and discovery at `${env}/.well-known/...`) for
+  // every resource; resource-scoped access tokens are signed with those same
+  // environment keys. Deriving the JWKS base from a resource-scoped issuer
+  // (`${env}/resources/<id>`) would hit a 404 and fail verification.
+  const jwksBase = config.environmentUrl.replace(/\/$/, "");
 
   // Resolve the JWKS once and cache the remote key set for the lifetime of the
   // middleware. createRemoteJWKSet maintains its own key cache, so building it
@@ -147,9 +154,9 @@ function scalekitMiddleware(config: Config): RequestHandler {
   const getJwks = (): Promise<JWTVerifyGetKey> => {
     if (!jwks) {
       jwks = (async () => {
-        let jwksUri = new URL(`${authServerBase}/keys`);
+        let jwksUri = new URL(`${jwksBase}/keys`);
         try {
-          const oidcUrl = `${authServerBase}/.well-known/openid-configuration`;
+          const oidcUrl = `${jwksBase}/.well-known/openid-configuration`;
           const response = await fetch(oidcUrl);
           if (response.ok) {
             const oidcConfig = (await response.json()) as { jwks_uri?: string };

--- a/packages/plugins/scalekit/src/provider.ts
+++ b/packages/plugins/scalekit/src/provider.ts
@@ -57,6 +57,24 @@ function getAuthServerBase(config: Config): string {
   return config.resourceId ? `${envUrl}/resources/${config.resourceId}` : envUrl;
 }
 
+// The set of `iss` values a valid access token may carry. Scalekit is migrating
+// this claim from the bare environment URL to a resource-scoped issuer, and both
+// forms are valid during the rollout — so we accept the bare URL plus, when a
+// resource is configured, its resource-scoped form. Derived entirely from the
+// existing config; nothing extra to configure. Intentionally broader than
+// getAuthServerBase, which must stay a single value for the OAuth AS metadata
+// (RFC 9728 / RFC 8414).
+function getExpectedIssuers(config: Config): readonly string[] {
+  const envUrl = config.environmentUrl.replace(/\/$/, "");
+  const issuers = new Set<string>([envUrl]);
+
+  if (config.resourceId) {
+    issuers.add(`${envUrl}/resources/${config.resourceId}`);
+  }
+
+  return [...issuers];
+}
+
 function scalekitRouter(config: Config): Router {
   const router = Router();
   const baseUrl = config.baseURL.replace(/\/$/, "");
@@ -119,6 +137,7 @@ function scalekitRouter(config: Config): Router {
 
 function scalekitMiddleware(config: Config): RequestHandler {
   const authServerBase = getAuthServerBase(config);
+  const expectedIssuers = getExpectedIssuers(config);
 
   // Pre-fetch JWKS URI from OIDC discovery
   let resolvedJwksUri: URL | null = null;
@@ -166,7 +185,7 @@ function scalekitMiddleware(config: Config): RequestHandler {
       const result = await verifyScalekitToken(
         token,
         jwksUrl,
-        authServerBase,
+        expectedIssuers,
         audience
       );
 

--- a/packages/plugins/scalekit/src/provider.ts
+++ b/packages/plugins/scalekit/src/provider.ts
@@ -10,7 +10,6 @@ import { contextProviderSession, contextProviderClient } from "./context.js";
 import type {
   Config,
   OAuthProtectedResourceMetadata,
-  OAuthAuthorizationServerMetadata,
 } from "./types.js";
 import {
   verifyScalekitToken,
@@ -97,41 +96,9 @@ function scalekitRouter(config: Config): Router {
     }
   );
 
-  router.get(
-    "/.well-known/oauth-authorization-server",
-    async (_req: Request, res: Response) => {
-      try {
-        const oidcUrl = `${authServerBase}/.well-known/openid-configuration`;
-        const response = await fetch(oidcUrl);
-
-        if (response.ok) {
-          const data = await response.json();
-          res.json(data);
-          return;
-        }
-
-        // Fallback
-        const metadata: OAuthAuthorizationServerMetadata = {
-          issuer: authServerBase,
-          authorization_endpoint: `${authServerBase}/oauth/authorize`,
-          token_endpoint: `${authServerBase}/oauth/token`,
-          jwks_uri: `${authServerBase}/keys`,
-          response_types_supported: ["code"],
-          grant_types_supported: ["authorization_code", "refresh_token"],
-          code_challenge_methods_supported: ["S256"],
-          token_endpoint_auth_methods_supported: [
-            "none",
-            "client_secret_post",
-          ],
-          scopes_supported: ["openid", "profile", "email", "offline_access"],
-        };
-        res.json(metadata);
-      } catch (error) {
-        console.error("[Scalekit] Failed to fetch OAuth metadata:", error);
-        res.status(500).json({ error: "Failed to get OAuth configuration" });
-      }
-    }
-  );
+  // Note: the authorization server metadata (RFC 8414) is served by Scalekit,
+  // not proxied here. Clients follow `authorization_servers` from the protected
+  // resource metadata above to Scalekit's own /.well-known endpoint.
 
   return router;
 }
@@ -139,13 +106,18 @@ function scalekitRouter(config: Config): Router {
 function scalekitMiddleware(config: Config): RequestHandler {
   const expectedIssuers = getExpectedIssuers(config);
 
-  // JWKS and OIDC discovery live at the environment root, NOT under the
-  // resource-scoped issuer that getAuthServerBase() returns. Scalekit serves the
-  // key set at `${env}/keys` (and discovery at `${env}/.well-known/...`) for
-  // every resource; resource-scoped access tokens are signed with those same
-  // environment keys. Deriving the JWKS base from a resource-scoped issuer
-  // (`${env}/resources/<id>`) would hit a 404 and fail verification.
+  // Discover the JWKS via the authorization server metadata (RFC 8414). For a
+  // resource-scoped issuer (`${env}/resources/<id>`) the metadata lives at
+  // `${env}/.well-known/oauth-authorization-server/resources/<id>` — the
+  // well-known segment is inserted after the origin, per RFC 8414 — and its
+  // `jwks_uri` points at the environment key set (`${env}/keys`). Resource-scoped
+  // access tokens are signed with those same environment keys. Fall back to
+  // `${env}/keys` if the metadata is unavailable.
   const jwksBase = config.environmentUrl.replace(/\/$/, "");
+  const resourcePath = config.resourceId
+    ? `/resources/${config.resourceId}`
+    : "";
+  const asMetadataUrl = `${jwksBase}/.well-known/oauth-authorization-server${resourcePath}`;
 
   // Resolve the JWKS once and cache the remote key set for the lifetime of the
   // middleware. createRemoteJWKSet maintains its own key cache, so building it
@@ -156,12 +128,11 @@ function scalekitMiddleware(config: Config): RequestHandler {
       jwks = (async () => {
         let jwksUri = new URL(`${jwksBase}/keys`);
         try {
-          const oidcUrl = `${jwksBase}/.well-known/openid-configuration`;
-          const response = await fetch(oidcUrl);
+          const response = await fetch(asMetadataUrl);
           if (response.ok) {
-            const oidcConfig = (await response.json()) as { jwks_uri?: string };
-            if (oidcConfig.jwks_uri) {
-              jwksUri = new URL(oidcConfig.jwks_uri);
+            const metadata = (await response.json()) as { jwks_uri?: string };
+            if (metadata.jwks_uri) {
+              jwksUri = new URL(metadata.jwks_uri);
             }
           }
         } catch {


### PR DESCRIPTION
Scalekit is migrating MCP token `iss` to a resource-scoped value. This keeps `@xmcp-dev/scalekit` working during that rollout: accept both issuers, resolve JWKS from RFC 8414 / `{env}/keys`, cache the key set, and stop hosting authorization-server metadata on the MCP server.

No public API or config changes.