### PR TITLE
Add Google tag (gtag.js) and upgrade @vercel/speed-insights to v2

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -7,6 +7,7 @@ import { Metadata } from "next";
 import { RootProvider } from "fumadocs-ui/provider";
 import DefaultSearchDialog from "@/components/search/search-default";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 import { Prefooter } from "@/components/layout/prefooter";
 import { Toaster } from "@/components/ui/toaster";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -133,6 +134,20 @@ export default function RootLayout({
         <WebMCPProvider />
         <Analytics />
         <SpeedInsights />
+        {/* Google tag (gtag.js) */}
+        <Script
+          async
+          src="https://www.googletagmanager.com/gtag/js?id=G-1H605RJV2K"
+        />
+        <Script id="gtag-init">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'G-1H605RJV2K');
+          `}
+        </Script>
       </body>
     </html>
   );

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -35,7 +35,7 @@
     "@types/mdx": "^2.0.13",
     "@types/three": "^0.178.1",
     "@vercel/analytics": "^1.6.1",
-    "@vercel/speed-insights": "^1.3.1",
+    "@vercel/speed-insights": "^2.0.0",
     "ai": "^6.0.197",
     "basehub": "^9.5.3",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(next@16.2.11(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/speed-insights':
-        specifier: ^1.3.1
-        version: 1.3.1(next@16.2.11(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        specifier: ^2.0.0
+        version: 2.0.0(next@16.2.11(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       ai:
         specifier: ^6.0.197
         version: 6.0.197(zod@4.1.13)
@@ -4469,11 +4469,12 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
-  '@vercel/speed-insights@1.3.1':
-    resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
     peerDependencies:
       '@sveltejs/kit': ^1 || ^2
       next: 16.2.11
+      nuxt: '>= 3'
       react: ^18 || ^19 || ^19.0.0-rc
       svelte: '>= 4'
       vue: ^3
@@ -4482,6 +4483,8 @@ packages:
       '@sveltejs/kit':
         optional: true
       next:
+        optional: true
+      nuxt:
         optional: true
       react:
         optional: true
@@ -12405,7 +12408,7 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@1.3.1(next@16.2.11(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
       next: 16.2.11(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4


### PR DESCRIPTION
## Summary

- Add the Google tag (gtag.js) for `G-1H605RJV2K` to the website root layout using Next's `<Script>` component, so it loads on every page.
- Upgrade `@vercel/speed-insights` from `^1.3.1` to `^2.0.0` (latest). The `@vercel/speed-insights/next` export and existing `<SpeedInsights />` usage are unchanged in v2, so no code changes were needed.
- Lockfile diff is limited to the speed-insights bump; unrelated `xmcp: latest` re-resolution drift was reverted and the lockfile validated with `pnpm install --frozen-lockfile`.

## Checks

- `tsc --noEmit`: no errors in the changed file (repo has pre-existing errors from missing `next build` generated types).
- `pnpm --filter website lint` fails identically on a clean tree (pre-existing eslint config error), so it can't gate this change.
- `pnpm --filter website build` requires `BASEHUB_TOKEN`, unavailable locally — please rely on the Vercel preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)