### PR TITLE
Add Ahrefs Analytics script to the website

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -148,6 +148,11 @@ export default function RootLayout({
             gtag('config', 'G-1H605RJV2K');
           `}
         </Script>
+        <Script
+          async
+          src="https://analytics.ahrefs.com/analytics.js"
+          data-key="3RwN0TIK29DoT05/h0pY1g"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
Adds the Ahrefs Analytics script to the website's root layout, right after the existing Google tag (gtag.js) scripts, using the same `next/script` pattern.

```tsx
<Script
  async
  src="https://analytics.ahrefs.com/analytics.js"
  data-key="3RwN0TIK29DoT05/h0pY1g"
/>
```

No new dependencies, no visual change, no docs or example needed — this is site instrumentation, not user-facing xmcp behavior (same shape as #623).

## Testing

`pnpm --filter website lint` currently fails on a clean tree in my environment with an ESLint 9 config error (`TypeError: Converting circular structure to JSON`), most likely from running Node 26 where the repo asks for Node 20. Verified pre-existing by stashing the change and re-running. CI lint/build should cover this five-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)