### PR TITLE
Add markdown mirrors for blog posts

### DIFF
--- a/apps/website/app/blog/[...slug]/page.tsx
+++ b/apps/website/app/blog/[...slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   resolveAuthors,
 } from "@/utils/blog";
 import { PostAuthors } from "@/components/blog/post-authors";
+import { PageActions } from "@/components/page-actions";
 import { getBaseUrl, SITE_URL } from "@/lib/base-url";
 import { JsonLd } from "@/components/seo/json-ld";
 import {
@@ -44,7 +45,16 @@ export default async function Page(props: PageProps<"/blog/[...slug]">) {
     : null;
 
   return (
-    <BlogPage toc={page.data.toc} slug={slug}>
+    <BlogPage
+      toc={page.data.toc}
+      slug={slug}
+      pageActions={
+        <PageActions
+          markdownUrl={`/blog/${slug}.md`}
+          trackLocation="blog_page_actions"
+        />
+      }
+    >
       {structuredData && <JsonLd data={structuredData} />}
       <div className="flex flex-col gap-4">
         {page.data.date && (
@@ -106,6 +116,9 @@ export async function generateMetadata(
     description,
     alternates: {
       canonical,
+      types: {
+        "text/markdown": `${canonical}.md`,
+      },
     },
     openGraph: {
       title,

--- a/apps/website/app/docs/[[...slug]]/page.tsx
+++ b/apps/website/app/docs/[[...slug]]/page.tsx
@@ -98,7 +98,9 @@ export async function generateMetadata(
   const title = meta.title + " | xmcp Documentation";
   const description = meta.summary ?? meta.description;
   const slugPath = params.slug?.join("/") ?? "";
-  const canonical = slugPath ? `${SITE_URL}/docs/${slugPath}` : `${SITE_URL}/docs`;
+  const canonical = slugPath
+    ? `${SITE_URL}/docs/${slugPath}`
+    : `${SITE_URL}/docs`;
 
   return {
     metadataBase: new URL(SITE_URL),
@@ -106,6 +108,9 @@ export async function generateMetadata(
     description,
     alternates: {
       canonical,
+      types: {
+        "text/markdown": `${canonical}.md`,
+      },
     },
     openGraph: {
       title,

--- a/apps/website/app/llms-blog.mdx/[...slug]/route.ts
+++ b/apps/website/app/llms-blog.mdx/[...slug]/route.ts
@@ -1,6 +1,6 @@
-import { getLLMText } from "../../../lib/get-llm-text";
+import { getBlogLLMText } from "../../../lib/get-llm-text";
 import { estimateTokens } from "../../../lib/estimate-tokens";
-import { source } from "../../../lib/source";
+import { blogSource } from "../../../lib/source";
 import { SITE_URL } from "../../../lib/base-url";
 import { notFound } from "next/navigation";
 
@@ -8,13 +8,13 @@ export const revalidate = false;
 
 export async function GET(
   _req: Request,
-  { params }: RouteContext<"/llms.mdx/[[...slug]]">
+  { params }: RouteContext<"/llms-blog.mdx/[...slug]">
 ) {
   const { slug } = await params;
-  const page = source.getPage(slug);
+  const page = blogSource.getPage(slug);
   if (!page) notFound();
 
-  const text = await getLLMText(page);
+  const text = await getBlogLLMText(page);
 
   return new Response(text, {
     headers: {
@@ -31,5 +31,5 @@ export async function GET(
 }
 
 export function generateStaticParams() {
-  return source.generateParams();
+  return blogSource.generateParams();
 }

--- a/apps/website/components/layout/blog.tsx
+++ b/apps/website/components/layout/blog.tsx
@@ -32,6 +32,7 @@ export interface BlogPageProps {
   toc?: TOCItemType[];
   children: ReactNode;
   slug?: string | string[];
+  pageActions?: ReactNode;
 }
 
 function TocItem({
@@ -59,7 +60,12 @@ function TocItem({
   );
 }
 
-export function BlogPage({ toc = [], slug, ...props }: BlogPageProps) {
+export function BlogPage({
+  toc = [],
+  slug,
+  pageActions,
+  ...props
+}: BlogPageProps) {
   const activeAnchors = useImprovedActiveAnchors(toc);
 
   return (
@@ -82,20 +88,24 @@ export function BlogPage({ toc = [], slug, ...props }: BlogPageProps) {
           </article>
         </div>
 
-        {toc.length > 0 && (
+        {(toc.length > 0 || pageActions) && (
           <aside className="hidden xl:flex xl:flex-col w-[286px] shrink-0 sticky top-[104px] h-[calc(100dvh-96px)] p-4 pt-0 gap-2 overflow-auto">
-            <p className="text-sm text-brand-white font-medium">
-              Table of contents
-            </p>
-            <nav className="flex flex-col pb-4 border-b border-white/20">
-              {toc.map((item) => (
-                <TocItem
-                  key={item.url}
-                  item={item}
-                  activeAnchors={activeAnchors}
-                />
-              ))}
-            </nav>
+            {toc.length > 0 && (
+              <>
+                <p className="text-sm text-brand-white font-medium">
+                  Table of contents
+                </p>
+                <nav className="flex flex-col pb-4 border-b border-white/20">
+                  {toc.map((item) => (
+                    <TocItem
+                      key={item.url}
+                      item={item}
+                      activeAnchors={activeAnchors}
+                    />
+                  ))}
+                </nav>
+              </>
+            )}
             {slug && (
               <div className="flex flex-wrap items-center gap-3 text-sm text-brand-neutral-50 w-full group hover:text-brand-white transition-colors">
                 <span className="inline-flex items-center gap-2 group-hover:text-brand-white transition-colors">
@@ -107,6 +117,7 @@ export function BlogPage({ toc = [], slug, ...props }: BlogPageProps) {
                 </span>
               </div>
             )}
+            {pageActions && <div className="mt-2">{pageActions}</div>}
           </aside>
         )}
       </div>

--- a/apps/website/components/page-actions.tsx
+++ b/apps/website/components/page-actions.tsx
@@ -8,13 +8,19 @@ import { track } from "@vercel/analytics";
 
 const cache = new Map<string, string>();
 
-export function PageActions({ markdownUrl }: { markdownUrl: string }) {
+export function PageActions({
+  markdownUrl,
+  trackLocation = "docs_page_actions",
+}: {
+  markdownUrl: string;
+  trackLocation?: string;
+}) {
   const [isLoading, setLoading] = useState(false);
   const [checked, onClick] = useCopyButton(async () => {
     track("docs action clicked", {
       action: "copy_markdown",
       markdownUrl: markdownUrl,
-      location: "docs_page_actions",
+      location: trackLocation,
     });
 
     const cached = cache.get(markdownUrl);
@@ -122,7 +128,7 @@ export function PageActions({ markdownUrl }: { markdownUrl: string }) {
             track("docs action clicked", {
               action: item.title.toLowerCase().replace(/\s+/g, "_"),
               markdownUrl: markdownUrl,
-              location: "docs_page_actions",
+              location: trackLocation,
               destination: item.href.toString(),
             });
           }}
@@ -140,7 +146,7 @@ export function PageActions({ markdownUrl }: { markdownUrl: string }) {
           track("docs action clicked", {
             action: "connect_mcp",
             markdownUrl: markdownUrl,
-            location: "docs_page_actions",
+            location: trackLocation,
           });
         }}
       >

--- a/apps/website/lib/get-llm-text.ts
+++ b/apps/website/lib/get-llm-text.ts
@@ -1,4 +1,4 @@
-import { source } from "./source";
+import { blogSource, source } from "./source";
 import type { InferPageType } from "fumadocs-core/source";
 
 const OAUTH_PLUGINS_MD = [
@@ -36,4 +36,53 @@ export async function getLLMText(page: InferPageType<typeof source>) {
   return `# ${page.data.title} (${page.url})
 
 ${expandComponents(processed)}`;
+}
+
+function blockquote(text: string): string {
+  return text
+    .trim()
+    .split("\n")
+    .map((line) => `> ${line}`.trimEnd())
+    .join("\n");
+}
+
+// These regexes run over the whole document, including fenced code blocks.
+// None of the expanded tags appear inside blog code fences today; if a new
+// component ever does, switch to a fence-aware splitter before expanding.
+function expandBlogComponents(md: string): string {
+  return md
+    .replace(
+      /<Callout([^>]*)>([\s\S]*?)<\/Callout>/g,
+      (_, attrs: string, children: string) => {
+        const title = attrs.match(/title="([^"]*)"/)?.[1];
+        return blockquote(
+          title ? `**${title}**\n${children.trim()}` : children
+        );
+      }
+    )
+    .replace(/<Video[^>]*?src="([^"]*)"[^>]*?\/>/g, "[Video]($1)")
+    .replace(
+      /<TerminalPrompt>\s*\{\s*("(?:[^"\\]|\\.)*")\s*\}\s*<\/TerminalPrompt>/g,
+      (match, literal: string) => {
+        try {
+          const text = JSON.parse(literal) as string;
+          return ["```", text.trimEnd(), "```"].join("\n");
+        } catch {
+          return match;
+        }
+      }
+    )
+    .replace(/<OAuthPlugins\s*\/>/g, OAUTH_PLUGINS_MD);
+}
+
+export async function getBlogLLMText(page: InferPageType<typeof blogSource>) {
+  const processed = await page.data.getText("processed");
+
+  const header = [`# ${page.data.title} (${page.url})`];
+  if (page.data.date) header.push(`Published: ${page.data.date}`);
+  if (page.data.description) header.push(page.data.description);
+
+  return `${header.join("\n\n")}
+
+${expandBlogComponents(processed)}`;
 }

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -75,12 +75,20 @@ const nextConfig: NextConfig = {
           has: acceptsMarkdown,
           destination: "/llms.mdx/:slug*",
         },
+        // `:slug+` (one or more segments) so the /blog index keeps its HTML.
+        {
+          source: "/blog/:slug+",
+          has: acceptsMarkdown,
+          destination: "/llms-blog.mdx/:slug+",
+        },
       ],
       afterFiles: [
         { source: "/docs/:slug*.md", destination: "/llms.mdx/:slug*" },
         { source: "/docs/:slug*.mdx", destination: "/llms.mdx/:slug*" },
         { source: "/docs.md", destination: "/llms.txt" },
         { source: "/docs.mdx", destination: "/llms.txt" },
+        { source: "/blog/:slug*.md", destination: "/llms-blog.mdx/:slug*" },
+        { source: "/blog/:slug*.mdx", destination: "/llms-blog.mdx/:slug*" },
       ],
     };
   },

--- a/apps/website/source.config.ts
+++ b/apps/website/source.config.ts
@@ -25,6 +25,9 @@ export const docs = defineDocs({
 export const blog = defineDocs({
   dir: "content/blog",
   docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
     schema: frontmatterSchema.extend({
       category: z.string().optional(),
       order: z.number().optional(),


### PR DESCRIPTION
Second of four AEO PRs (follows #624). Gives all 34 blog posts — including the 19 unlisted SEO articles — the same machine-readable surface docs already have.

## Changes

- **`source.config.ts`**: enable `postprocess.includeProcessedMarkdown` on the blog source so `getText("processed")` works for `blogSource` pages.
- **`lib/get-llm-text.ts`**: `getBlogLLMText` renders `# title (url)` + published date + description, then expands the four JSX components used in blog prose: `<Callout>` → blockquote (bold title prefix), `<Video src>` → `[Video](src)`, `<TerminalPrompt>` → code fence, `<OAuthPlugins />` → the existing links list. Verified against all 34 posts: zero raw JSX leaks, and code fences (which contain JSX-looking code like `ProductGrid`) are untouched — fence counts match the sources. A comment documents the fence-awareness upgrade path if a new component appears in prose.
- **`app/llms-blog.mdx/[...slug]/route.ts`**: mirror of the docs `llms.mdx` route with `Content-Type: text/markdown`, `Vary: Accept`, `X-Content-Type-Options: nosniff`, `x-markdown-tokens`, and `Link: <html twin>; rel="canonical"` so the mirror never competes with the HTML page in indexes. The canonical `Link` + `nosniff` were also added to the docs route for parity.
- **`next.config.ts`**: `/blog/:slug*.md`/`.mdx` suffix rewrites and `Accept: text/markdown` negotiation on `/blog/:slug+` (`+` so the `/blog` index keeps serving HTML — its markdown twin comes in the next PR).
- **Metadata**: docs and blog pages now emit `<link rel="alternate" type="text/markdown" href="….md">` via `alternates.types`.
- **PageActions on blog**: `BlogPage` gains a `pageActions` slot (rendered under the TOC, same as docs); `PageActions` gains an optional `trackLocation` prop (default unchanged) so analytics separate `blog_page_actions` from `docs_page_actions`.

Deliberately not added: `Link: rel="alternate"` response headers on `/docs/:slug*`/`/blog/:slug+` via `headers()` — the source pattern would also match `.md` request paths and advertise broken `.md.md` URLs. The in-band `<link>` tag plus llms.txt covers discovery; the homepage RFC 8288 `Link` headers are unchanged.

## Verification (dev server curls)

- `/blog/what-is-an-mcp-server.md` → markdown with all five headers; same URL with `Accept: text/markdown` on the HTML path negotiates correctly.
- Component expansion spot-checked on `securing-your-mcp-server` (OAuthPlugins), `better-auth-integration` (Callout with/without title), `mcp-apps` (TerminalPrompt), plus a leak sweep across all 34 mirrors.
- `apps-monetization.md`: 14 code fences in = 14 out; fenced `<ProductGrid>` preserved verbatim.
- `/blog` with `Accept: text/markdown` still returns HTML.
- `next build`: compiles + typechecks clean; full prerender needs `BASEHUB_TOKEN` (Vercel CI has it). Lint remains broken-on-clean-checkout in this environment (Node 26 vs repo's Node 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)