### PR TITLE
Add homepage/blog/templates markdown twins and expand llms.txt sitewide

### DIFF
--- a/apps/website/app/blog.md/route.ts
+++ b/apps/website/app/blog.md/route.ts
@@ -1,0 +1,38 @@
+import { getListedBlogPosts } from "../../utils/blog";
+import { estimateTokens } from "../../lib/estimate-tokens";
+import { SITE_URL } from "../../lib/base-url";
+
+export const revalidate = false;
+
+// Markdown twin of the /blog index. Mirrors the on-site listing, so unlisted
+// "ghost" posts are excluded here — they are indexed via /llms.txt instead.
+export function GET() {
+  const lines = [
+    "# xmcp Blog",
+    "> Guides, release notes, and engineering articles about building TypeScript MCP servers and production-ready agent tools.",
+  ];
+
+  const entries = getListedBlogPosts().map((post) => {
+    const parts = [`- [${post.title}](${SITE_URL}/blog/${post.slug}.md)`];
+    if (post.date) parts.push(post.date);
+    const description = post.description ?? post.summary;
+    if (description) parts.push(description);
+    return parts.join(" — ");
+  });
+  lines.push(entries.join("\n"));
+
+  const text = lines.join("\n\n");
+
+  return new Response(text, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      // This route is the markdown half of Accept-based content negotiation,
+      // so caches must key on Accept to avoid mixing it with the HTML page.
+      Vary: "Accept",
+      "X-Content-Type-Options": "nosniff",
+      // The HTML index stays the sole indexable URL.
+      Link: `<${SITE_URL}/blog>; rel="canonical"`,
+      "x-markdown-tokens": String(estimateTokens(text)),
+    },
+  });
+}

--- a/apps/website/app/blog/page.tsx
+++ b/apps/website/app/blog/page.tsx
@@ -14,6 +14,9 @@ export const metadata = {
     "Read xmcp guides, release notes, and engineering articles about building TypeScript MCP servers and production-ready agent tools.",
   alternates: {
     canonical: "https://xmcp.dev/blog",
+    types: {
+      "text/markdown": "https://xmcp.dev/blog.md",
+    },
   },
   openGraph: {
     title: "xmcp Blog - MCP Guides, Releases, and Engineering Notes",

--- a/apps/website/app/index.md/route.ts
+++ b/apps/website/app/index.md/route.ts
@@ -1,0 +1,56 @@
+import { estimateTokens } from "../../lib/estimate-tokens";
+import { SITE_URL } from "../../lib/base-url";
+
+export const revalidate = false;
+
+// Hand-authored markdown twin of the homepage. The visual homepage is
+// component-driven, so this file is the plain-text entity description that
+// answer engines can read and cite.
+const HOMEPAGE_MD = `# xmcp — The TypeScript MCP framework
+
+> xmcp is a framework for building and shipping MCP servers with TypeScript. Designed with DX in mind, it simplifies setup and removes friction in just one command — making it easy to build & deploy AI tools on top of the Model Context Protocol ecosystem.
+
+xmcp automatically registers tools, prompts, and resources from your project files. It supports HTTP and STDIO transports and ships with authentication integrations, deployment adapters for existing Next.js and Express apps, and monetization plugins.
+
+Get started:
+
+\`\`\`bash
+npx create-xmcp-app@latest
+\`\`\`
+
+## Key pages
+
+- [Documentation](${SITE_URL}/docs): guides for getting started, configuration, authentication, adapters, and deployment
+- [Blog](${SITE_URL}/blog): guides, release notes, and engineering articles
+- [Templates](${SITE_URL}/templates): production-ready MCP server templates to fork and deploy
+- [Showcase](${SITE_URL}/showcase): MCP servers built with xmcp
+
+## Markdown mirrors
+
+Append \`.md\` to any docs or blog URL for a markdown version of that page, or send \`Accept: text/markdown\` to the HTML URL.
+
+- [llms.txt](${SITE_URL}/llms.txt): index of all docs, blog posts, and templates
+- [llms-full.txt](${SITE_URL}/llms-full.txt): complete documentation content in one file
+
+## Source
+
+- [GitHub](https://github.com/basementstudio/xmcp)
+- [npm](https://www.npmjs.com/package/xmcp)
+
+Built by [basement.studio](https://basement.studio).
+`;
+
+export function GET() {
+  return new Response(HOMEPAGE_MD, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      // This route is the markdown half of Accept-based content negotiation,
+      // so caches must key on Accept to avoid mixing it with the HTML page.
+      Vary: "Accept",
+      "X-Content-Type-Options": "nosniff",
+      // The HTML homepage stays the sole indexable URL.
+      Link: `<${SITE_URL}/>; rel="canonical"`,
+      "x-markdown-tokens": String(estimateTokens(HOMEPAGE_MD)),
+    },
+  });
+}

--- a/apps/website/app/llms.txt/route.ts
+++ b/apps/website/app/llms.txt/route.ts
@@ -1,6 +1,10 @@
 import { source } from "../../lib/source";
+import { getAllBlogPosts } from "../../utils/blog";
+import { fetchTemplates } from "../templates/utils/github";
 
-export const revalidate = false;
+// Templates come from the GitHub API, so this file revalidates on the same
+// window as the /templates pages instead of being fully static.
+export const revalidate = 1800;
 
 export async function GET() {
   const scanned: string[] = [];
@@ -27,5 +31,46 @@ export async function GET() {
     scanned.push(value.join("\n"));
   }
 
-  return new Response(scanned.join("\n\n"));
+  // Deliberately includes unlisted "ghost" posts: they are hidden from
+  // on-site listings but published for search and answer engines, and this
+  // index is their machine-facing discovery channel.
+  scanned.push("## Blog");
+  scanned.push(
+    getAllBlogPosts()
+      .map((post) => {
+        const description = post.description ?? post.summary;
+        const link = `- [${post.title}](/blog/${post.slug})`;
+        return description ? `${link}: ${description}` : link;
+      })
+      .join("\n")
+  );
+
+  // fetchTemplates returns [] when the GitHub API is unavailable; the docs
+  // and blog sections above never depend on that fetch.
+  const templates = await fetchTemplates();
+  if (templates.length > 0) {
+    scanned.push("## Templates");
+    scanned.push(
+      templates
+        .map(
+          (template) =>
+            `- [${template.name}](/templates/${template.slug}): ${template.description}`
+        )
+        .join("\n")
+    );
+  }
+
+  scanned.push("## Optional");
+  scanned.push(
+    [
+      "- [llms-full.txt](/llms-full.txt): complete documentation content in one file",
+      "- [index.md](/index.md): site overview in markdown",
+    ].join("\n")
+  );
+
+  return new Response(scanned.join("\n\n"), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
 }

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -15,6 +15,9 @@ export const metadata: Metadata = {
     "xmcp is the TypeScript framework for building, shipping, and scaling Model Context Protocol servers — tools, prompts, resources, auth, transports, and monetization out of the box.",
   alternates: {
     canonical: "https://xmcp.dev",
+    types: {
+      "text/markdown": "https://xmcp.dev/index.md",
+    },
   },
 };
 

--- a/apps/website/app/templates.md/route.ts
+++ b/apps/website/app/templates.md/route.ts
@@ -1,0 +1,45 @@
+import { fetchTemplates } from "../templates/utils/github";
+import { estimateTokens } from "../../lib/estimate-tokens";
+import { SITE_URL } from "../../lib/base-url";
+
+// Matches the /templates pages and sitemap, which use the same GitHub-backed
+// fetch with this revalidation window.
+export const revalidate = 1800;
+
+export async function GET() {
+  const lines = [
+    "# xmcp Templates",
+    "> Production-ready MCP server templates built with xmcp — authentication, transports, monetization, and integrations you can fork and deploy.",
+  ];
+
+  // fetchTemplates returns [] when the GitHub API is unavailable; keep the
+  // header so the route degrades instead of failing.
+  const templates = await fetchTemplates();
+  if (templates.length > 0) {
+    const entries = templates.map((template) => {
+      const parts = [
+        `- [${template.name}](${SITE_URL}/templates/${template.slug})`,
+      ];
+      if (template.category) parts.push(`(${template.category})`);
+      if (template.description) parts.push(`— ${template.description}`);
+      parts.push(`— [source](${template.repositoryUrl})`);
+      return parts.join(" ");
+    });
+    lines.push(entries.join("\n"));
+  }
+
+  const text = lines.join("\n\n");
+
+  return new Response(text, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      // This route is the markdown half of Accept-based content negotiation,
+      // so caches must key on Accept to avoid mixing it with the HTML page.
+      Vary: "Accept",
+      "X-Content-Type-Options": "nosniff",
+      // The HTML index stays the sole indexable URL.
+      Link: `<${SITE_URL}/templates>; rel="canonical"`,
+      "x-markdown-tokens": String(estimateTokens(text)),
+    },
+  });
+}

--- a/apps/website/app/templates/page.tsx
+++ b/apps/website/app/templates/page.tsx
@@ -15,6 +15,9 @@ export const metadata: Metadata = {
     "Explore templates to get started with xmcp. Learn from real-world implementations and best practices.",
   alternates: {
     canonical: `${SITE_URL}/templates`,
+    types: {
+      "text/markdown": `${SITE_URL}/templates.md`,
+    },
   },
   openGraph: {
     title: "Templates - xmcp",

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -69,7 +69,13 @@ const nextConfig: NextConfig = {
     ];
     return {
       beforeFiles: [
-        { source: "/", has: acceptsMarkdown, destination: "/llms.mdx" },
+        { source: "/", has: acceptsMarkdown, destination: "/index.md" },
+        { source: "/blog", has: acceptsMarkdown, destination: "/blog.md" },
+        {
+          source: "/templates",
+          has: acceptsMarkdown,
+          destination: "/templates.md",
+        },
         {
           source: "/docs/:slug*",
           has: acceptsMarkdown,
@@ -106,6 +112,7 @@ const nextConfig: NextConfig = {
               '</docs>; rel="service-doc"; type="text/html"',
               '</llms.txt>; rel="service-desc"; type="text/plain"',
               '</llms-full.txt>; rel="describedby"; type="text/plain"',
+              '</index.md>; rel="alternate"; type="text/markdown"',
             ].join(", "),
           },
         ],


### PR DESCRIPTION
Third of four AEO PRs (follows #624 and #626). Completes markdown coverage for the non-docs surfaces and turns llms.txt into a full-site index.

## Changes

- **`app/index.md/route.ts`**: hand-authored markdown twin of the homepage — the plain-text entity description answer engines can read and cite (the visual homepage is component-driven and exposes little crawlable text). Content sticks to established copy: the docs-index description, install command, key page links, the `.md`/`Accept: text/markdown` convention, GitHub/npm.
- **Fixed `/` negotiation defect**: `Accept: text/markdown` on `/` previously rewrote to `/llms.mdx` with no slug, which served the *docs index*. It now serves `/index.md`.
- **`app/blog.md/route.ts`**: markdown twin of the `/blog` index from `getListedBlogPosts()` — mirrors the on-site listing honestly (ghost posts excluded here; they're covered in llms.txt). Entries link to the `.md` mirrors from #626.
- **`app/templates.md/route.ts`**: generated from `fetchTemplates()` with the same `revalidate = 1800` as the `/templates` pages; degrades to a header-only file if the GitHub API returns nothing.
- **Negotiation**: `/blog` and `/templates` index pages now answer `Accept: text/markdown`. All three twins send the same header contract as the page mirrors: `text/markdown`, `Vary: Accept`, `nosniff`, `Link: rel="canonical"` to the HTML twin, `x-markdown-tokens`.
- **`app/llms.txt/route.ts`**: now indexes the whole site — docs sections unchanged, `## Blog` with all 34 posts **including the 19 unlisted ghost articles** (deliberate and commented: llms.txt is their machine-facing discovery channel, matching the existing sitemap-yes/listing-no convention), `## Templates` when the fetch succeeds (docs/blog sections never depend on it), and `## Optional` linking `llms-full.txt` + `index.md`. `revalidate` moves from `false` to `1800` because of the GitHub dependency; explicit `text/plain; charset=utf-8`.
- **Discovery**: homepage `Link` header gains `</index.md>; rel="alternate"; type="text/markdown"`; home, blog index, and templates index advertise their twins via `alternates.types`.

## Verification (dev server curls)

- `curl -H "Accept: text/markdown" /` returns the xmcp facts file (not the docs index) — the PR's headline fix.
- `/index.md`, `/blog.md`, `/templates.md` all return markdown with the full header set; `/blog` and `/templates` negotiate correctly.
- `/llms.txt`: docs sections intact, 34 blog entries, `## Templates` with 13 entries when run with a `GITHUB_TOKEN` (unauthenticated local runs hit rate limits and correctly degrade to no Templates section), `## Optional` present.
- Regression: `/docs.md` still serves the docs index markdown; `/blog/<slug>.md` mirrors unaffected.
- `next build` compiles + typechecks clean; Prettier clean on all touched files. Full prerender still needs `BASEHUB_TOKEN` (Vercel CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)