### PR TITLE
Add missing JSON-LD schemas and stable Organization @id

### DIFF
--- a/apps/website/app/blog/page.tsx
+++ b/apps/website/app/blog/page.tsx
@@ -5,6 +5,9 @@ import {
 } from "../../utils/blog";
 import { BlogHero } from "../../components/blog/hero";
 import { BlogCard } from "@/components/home/blog";
+import { JsonLd } from "@/components/seo/json-ld";
+import { getBlogCollectionSchema } from "@/lib/structured-data";
+import { SITE_URL } from "@/lib/base-url";
 
 export const dynamic = "force-static";
 
@@ -44,6 +47,7 @@ export default function BlogPage() {
 
   return (
     <main className="grid grid-cols-12 gap-[20px] max-w-[1200px] w-full mx-auto px-4">
+      <JsonLd data={getBlogCollectionSchema(posts, SITE_URL)} />
       <div className="col-span-full grid grid-cols-12 gap-y-8 py-8 md:py-16">
         <div className="flex flex-col items-center justify-center max-w-[720px] w-full mx-auto gap-4 col-span-12 mb-8">
           <h1 className="display text-center text-balance z-10 text-gradient">

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -6,6 +6,9 @@ import { HomeBlog } from "@/components/home/blog";
 import { HomeTestimonials } from "@/components/home/testimonials";
 import { getLatestVersion } from "@/lib/get-version";
 import { FaqBlock } from "@/components/seo/faq-block";
+import { JsonLd } from "@/components/seo/json-ld";
+import { getSoftwareApplicationSchema } from "@/lib/structured-data";
+import { SITE_URL } from "@/lib/base-url";
 
 export const dynamic = "force-static";
 
@@ -26,6 +29,7 @@ export default async function Home() {
 
   return (
     <main className="grid grid-cols-12 gap-[20px] max-w-[1200px] w-full mx-auto px-4">
+      <JsonLd data={getSoftwareApplicationSchema(SITE_URL)} />
       <HomeHero version={version} />
       <HomeFeatures />
       <HomeSteps />

--- a/apps/website/app/templates/[slug]/page.tsx
+++ b/apps/website/app/templates/[slug]/page.tsx
@@ -24,6 +24,8 @@ import { TemplateReadmeContent } from "@/components/templates/detail/readme-cont
 import { TemplateDetailSidebar } from "@/components/templates/detail/sidebar";
 import { getBaseUrl, SITE_URL } from "@/lib/base-url";
 import { resolveTemplatePreviewImage } from "@/lib/template-preview-image";
+import { JsonLd } from "@/components/seo/json-ld";
+import { getBreadcrumbSchema } from "@/lib/structured-data";
 
 export const revalidate = 1800; // 30 minutes
 
@@ -126,9 +128,7 @@ export default async function TemplateDetailPage(
     ])
   );
   const validCategorySlugs = new Set(
-    collectUniqueCategories(items).map((category) =>
-      slugifyCategory(category)
-    )
+    collectUniqueCategories(items).map((category) => slugifyCategory(category))
   );
   const previewImage = resolveTemplatePreviewImage(template);
   const displayName = normalizeDisplayLabel(template.name);
@@ -140,6 +140,16 @@ Add a README.md to this template to show content here.`;
 
   return (
     <main className="max-w-[1200px] w-full mx-auto px-4 py-12 md:py-16 space-y-10">
+      <JsonLd
+        data={getBreadcrumbSchema(
+          [
+            { name: "Home", url: "/" },
+            { name: "Templates", url: "/templates" },
+            { name: displayName, url: `/templates/${template.slug}` },
+          ],
+          SITE_URL
+        )}
+      />
       <TemplateBreadcrumb name={displayName} />
 
       <div className="space-y-4 md:space-y-6">

--- a/apps/website/app/templates/page.tsx
+++ b/apps/website/app/templates/page.tsx
@@ -3,6 +3,8 @@ import { getBaseUrl, SITE_URL } from "@/lib/base-url";
 import { fetchTemplates } from "@/app/templates/utils/github";
 import { TemplatesListing } from "@/components/templates/listing";
 import { collectUniqueCategories } from "@/app/templates/utils/categories";
+import { JsonLd } from "@/components/seo/json-ld";
+import { getTemplatesItemListSchema } from "@/lib/structured-data";
 
 export const dynamic = "force-static";
 export const revalidate = 1800; // 30 minutes
@@ -52,6 +54,9 @@ export default async function TemplatesPage() {
 
   return (
     <main className="grid grid-cols-12 gap-[20px] max-w-[1200px] w-full mx-auto px-4">
+      {templates.length > 0 && (
+        <JsonLd data={getTemplatesItemListSchema(templates, SITE_URL)} />
+      )}
       <TemplatesListing
         templates={templates}
         categories={categories}

--- a/apps/website/lib/structured-data.ts
+++ b/apps/website/lib/structured-data.ts
@@ -10,8 +10,13 @@ const ORG_SAME_AS = [
 const absolute = (baseUrl: string, path: string): string =>
   new URL(path, baseUrl).toString();
 
+// Stable @id so every publisher/creator reference across the page's scripts
+// merges into the one Organization node instead of creating blank-node copies.
+const orgId = (baseUrl: string) => `${baseUrl}/#organization`;
+
 const orgRef = (baseUrl: string) => ({
   "@type": "Organization",
+  "@id": orgId(baseUrl),
   name: ORG_NAME,
   url: baseUrl,
 });
@@ -30,10 +35,75 @@ export function getOrganizationSchema(baseUrl: string) {
   return {
     "@context": "https://schema.org",
     "@type": "Organization",
+    "@id": orgId(baseUrl),
     name: ORG_NAME,
     url: baseUrl,
     logo: absolute(baseUrl, "/favicon.svg"),
     sameAs: ORG_SAME_AS,
+  };
+}
+
+export function getSoftwareApplicationSchema(baseUrl: string) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: ORG_NAME,
+    description:
+      "xmcp is the TypeScript framework for building, shipping, and scaling Model Context Protocol servers — tools, prompts, resources, auth, transports, and monetization out of the box.",
+    url: baseUrl,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Node.js",
+    offers: {
+      "@type": "Offer",
+      price: 0,
+      priceCurrency: "USD",
+    },
+    sameAs: [...ORG_SAME_AS, "https://www.npmjs.com/package/xmcp"],
+    publisher: orgRef(baseUrl),
+  };
+}
+
+export function getBlogCollectionSchema(
+  posts: readonly BlogPost[],
+  baseUrl: string
+) {
+  const url = absolute(baseUrl, "/blog");
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "xmcp Blog",
+    url,
+    mainEntityOfPage: url,
+    publisher: orgRef(baseUrl),
+    hasPart: posts.map((post) => ({
+      "@type": "BlogPosting",
+      headline: post.title,
+      url: absolute(baseUrl, `/blog/${post.slug}`),
+    })),
+  };
+}
+
+export interface TemplateListItem {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+}
+
+export function getTemplatesItemListSchema(
+  templates: readonly TemplateListItem[],
+  baseUrl: string
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    itemListElement: templates.map((template, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: template.name,
+      description: template.description,
+      url: absolute(baseUrl, `/templates/${template.slug}`),
+    })),
   };
 }
 
@@ -100,10 +170,7 @@ export function getTechArticleSchema(
   };
 }
 
-export function getBreadcrumbSchema(
-  items: BreadcrumbItem[],
-  baseUrl: string
-) {
+export function getBreadcrumbSchema(items: BreadcrumbItem[], baseUrl: string) {
   return {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",


### PR DESCRIPTION
Last of the four AEO PRs (follows #624, #626, #627). Fills the structured-data gaps found in the audit.

## Changes

- **Stable entity identity**: the sitewide Organization node now carries `@id: "https://xmcp.dev/#organization"`, and every `publisher`/reference emitted by the schema builders carries the same `@id`. Parsers merge them into one entity instead of accumulating blank-node Organization duplicates on every page (the cheap version of basement's `@graph` consolidation — full per-page graph assembly was deliberately skipped as a broad rewrite for marginal benefit).
- **`SoftwareApplication` on the homepage**: xmcp itself finally has a software entity (`DeveloperApplication`, `operatingSystem: Node.js`, free `Offer`, `sameAs` GitHub + npm). Previously the home page only described the Organization/WebSite and FAQ.
- **`CollectionPage` on `/blog`**: lists the visible posts as `BlogPosting` parts (headline + url).
- **`ItemList` on `/templates`**: one `ListItem` per template; skipped entirely when the GitHub fetch returns nothing, so no empty-list schema is ever emitted.
- **`BreadcrumbList` on `/templates/:slug`**: the page had a visual breadcrumb but no schema; docs and blog already had it.

## Verification

- Schema builders executed directly (they're pure, type-only imports): Organization `@id`, publisher refs, `hasPart`, and `ListItem` output all correct — e.g. `publisher: {"@type":"Organization","@id":"https://xmcp.dev/#organization",…}`.
- `next build` compiles + typechecks clean; Prettier clean.
- The blog/templates HTML pages can't render locally (basehub token required for dev/prerender), so the rendered `<script type="application/ld+json">` tags should be spot-checked on the Vercel preview — paste `/`, `/blog`, `/templates`, and a template detail page into the Schema.org validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)