### PR TITLE
Make markdown index routes fully static

### DIFF
--- a/apps/website/app/llms.txt/route.ts
+++ b/apps/website/app/llms.txt/route.ts
@@ -2,9 +2,7 @@ import { source } from "../../lib/source";
 import { getAllBlogPosts } from "../../utils/blog";
 import { fetchTemplates } from "../templates/utils/github";
 
-// Templates come from the GitHub API, so this file revalidates on the same
-// window as the /templates pages instead of being fully static.
-export const revalidate = 1800;
+export const revalidate = false;
 
 export async function GET() {
   const scanned: string[] = [];

--- a/apps/website/app/templates.md/route.ts
+++ b/apps/website/app/templates.md/route.ts
@@ -2,9 +2,7 @@ import { fetchTemplates } from "../templates/utils/github";
 import { estimateTokens } from "../../lib/estimate-tokens";
 import { SITE_URL } from "../../lib/base-url";
 
-// Matches the /templates pages and sitemap, which use the same GitHub-backed
-// fetch with this revalidation window.
-export const revalidate = 1800;
+export const revalidate = false;
 
 export async function GET() {
   const lines = [


### PR DESCRIPTION
> **Important: Please ensure your pull request is targeting the `main` branch. PRs to other branches may be closed or require retargeting.**

## Summary

- Set `revalidate = false` for `/llms.txt` and `/templates.md`.
- Remove comments describing the previous 30-minute revalidation window.

This follows up on #627. No docs, runnable example, or screenshots are needed because this only changes website route caching behavior.

## Type of Change

- [x] Bug fixing
- [ ] Adding a feature
- [ ] Improving documentation
- [ ] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [ ] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [ ] Plugins
- [x] Documentation
- [ ] Examples

## Contributor Checklist

- [x] I read `AGENTS.md` and the scoped rules for the areas I touched.
- [x] I kept this PR focused on the stated change.
- [ ] I ran the relevant build, lint, test, or example checks. (`git diff --check` passes; website lint could not run because local dependencies are not installed.)
- [x] I updated docs and a runnable example for user-facing behavior, or explained why an example does not fit.
- [x] I checked `REVIEW_RULES.md` for logging, timers, config shape, wrappers, compiler/loader changes, and stale examples.

## Screenshots/Examples

Not applicable; there is no visual change.

## Related Issues

Follow-up to #627.