### PR TITLE
Put the footer Open Source Program credit on one line

### DIFF
--- a/apps/website/components/layout/footer/index.tsx
+++ b/apps/website/components/layout/footer/index.tsx
@@ -11,16 +11,14 @@ export const Footer = () => {
           © xmcp {year} All rights reserved.
         </span>
       </div>
-      <div className="flex-1 flex flex-col items-center justify-end gap-1 z-100 text-brand-neutral-200">
+      <div className="flex-1 flex items-center justify-center z-100 text-brand-neutral-200">
         <AnimatedLink
           href="https://vercel.com/oss"
           target="_blank"
           rel="noopener noreferrer"
-          className="flex flex-col items-center gap-1 text-brand-neutral-200 hover:text-white transition-colors"
+          className="flex items-center gap-2 text-brand-neutral-200 hover:text-white transition-colors"
         >
-          <span className="text-xs uppercase tracking-wider">
-            Open Source Program
-          </span>
+          <span>Open Source Program</span>
           <Icons.vercelGeist aria-hidden="true" className="h-3.5 w-auto" />
         </AnimatedLink>
       </div>


### PR DESCRIPTION
Small footer tweak: the Vercel OSS credit was stacked (all-caps label above the logo). It now sits on a single line — copy then logo — and drops `uppercase`/`text-xs` so it reads in title case at the same scale as the copyright line and the NPM/GitHub/X/Discord links.

Markup and link target are otherwise unchanged.

## Verification

- `pnpm exec next build` — compiles and passes TypeScript.
- **Skipped:** the prerender step fails on the missing `BASEHUB_TOKEN`, which blocks every HTML route locally (untouched routes included). Vercel CI has the token, so the preview is the place to eyeball this one.
- **Skipped:** `pnpm --filter website lint` — the ESLint config crashes on a clean checkout under Node 26 in this workspace (repo targets Node 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)