### PR TITLE
feat: emit ESM server bundles for type-module projects

### DIFF
--- a/.changeset/esm-build-output.md
+++ b/.changeset/esm-build-output.md
@@ -1,0 +1,5 @@
+---
+"@xmcp-dev/compiler": minor
+---
+
+Emit ESM server bundles when the application's `package.json` declares `"type": "module"`. The build writes a `dist/package.json` module marker so the self-contained output keeps running when deployed without the project, and node builtins resolve through `createRequire`. Projects without the field keep CommonJS output unchanged.

--- a/apps/website/content/docs/getting-started/installation.mdx
+++ b/apps/website/content/docs/getting-started/installation.mdx
@@ -99,6 +99,11 @@ You can then run the scripts based on the package manager you've set up.
 Based on the transport you've chosen when bootstrapping your project, the [transport] placeholder will be replaced with the appropriate one.
 This is correlated with the `xmcp.config.ts` configuration.
 
+The output format follows your project's `package.json`: with `"type": "module"`
+the build emits ES modules (and writes a `dist/package.json` marker so the
+self-contained `dist` directory keeps running when deployed on its own);
+otherwise it emits CommonJS. No configuration is needed either way.
+
 ## Troubleshooting
 
 If you encounter issues when running the built server, make sure the transport is matching the configured one in `xmcp.config.ts`.

--- a/examples/http-transport/package.json
+++ b/examples/http-transport/package.json
@@ -1,6 +1,7 @@
 {
   "name": "HTTP Transport",
   "private": true,
+  "type": "module",
   "description": "Learn how to set up an xmcp server using HTTP transport",
   "keywords": [
     "transport",

--- a/packages/compiler/src/compiler/get-bundler-config/get-externals.ts
+++ b/packages/compiler/src/compiler/get-bundler-config/get-externals.ts
@@ -8,7 +8,9 @@ import { RspackOptions } from "@rspack/core";
  * We want to avoid building node modules.
  * When using Next.js, we want to avoid building tools/*, since the nextjs compiler will handle that code.
  */
-export function getExternals(): RspackOptions["externals"] {
+export function getExternals(
+  esmOutput = false
+): RspackOptions["externals"] {
   const xmcpConfig = getXmcpConfig();
 
   const replacedImports = new Set<string>();
@@ -28,6 +30,12 @@ export function getExternals(): RspackOptions["externals"] {
         builtinModules.includes(request) ||
         builtinModules.includes(request.replace(/^node:/, ""));
       if (isBuiltinModule) {
+        // In ESM output the unprefixed request falls back to the config's
+        // externalsType ("node-commonjs"), which resolves builtins through
+        // createRequire so both import and require usages keep working.
+        if (esmOutput) {
+          return callback(undefined, request);
+        }
         return callback(undefined, `commonjs ${request}`);
       }
 

--- a/packages/compiler/src/compiler/get-bundler-config/index.ts
+++ b/packages/compiler/src/compiler/get-bundler-config/index.ts
@@ -13,6 +13,7 @@ import {
   adapterOutputPath,
   cloudflareOutputPath,
   resolveXmcpSrcPath,
+  runtimeFolderPath,
 } from "@/utils/constants";
 import { compilerContext } from "@/compiler/compiler-context";
 import { XmcpConfigOutputSchema } from "@/runtime-config";
@@ -21,12 +22,25 @@ import { getInjectedVariables } from "./get-injected-variables";
 import { resolveTsconfigPathsToAlias } from "./resolve-tsconfig-paths";
 import {
   CreateTypeDefinitionPlugin,
+  EmitModulePackageJsonPlugin,
   InjectRuntimePlugin,
   readClientBundlesFromDisk,
 } from "./plugins";
 import { getExternals } from "./get-externals";
 import { TsCheckerRspackPlugin } from "ts-checker-rspack-plugin";
 import fs from "fs";
+
+/** Reads the project's package.json "type" field to infer the output format */
+function projectPrefersEsm(projectFolder: string): boolean {
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(projectFolder, "package.json"), "utf-8")
+    ) as { type?: string };
+    return packageJson.type === "module";
+  } catch {
+    return false;
+  }
+}
 
 /** Creates the bundler configuration that xmcp will use to bundle the user's code */
 export function getRspackConfig(
@@ -36,6 +50,13 @@ export function getRspackConfig(
   const { mode, platforms } = compilerContext.getContext();
 
   const isCloudflare = !!platforms.cloudflare;
+  // ESM output only applies to the plain node server builds: Cloudflare is
+  // already ESM, and adapter output is consumed by the host framework's
+  // own module pipeline.
+  const isEsmOutput =
+    !isCloudflare &&
+    !xmcpConfig.experimental?.adapter &&
+    projectPrefersEsm(processFolder);
   const projectZodPath = path.join(processFolder, "node_modules", "zod");
   const zodAliases: ResolveAlias = fs.existsSync(projectZodPath)
     ? {
@@ -122,7 +143,7 @@ export function getRspackConfig(
       filename: outputFilename,
       path: outputPath,
       globalObject: "globalThis",
-      ...(isCloudflare
+      ...(isCloudflare || isEsmOutput
         ? {
             library: { type: "module" },
             chunkFormat: "module",
@@ -139,8 +160,19 @@ export function getRspackConfig(
       },
     },
     target: isCloudflare ? "webworker" : "node",
-    externals: isCloudflare ? { async_hooks: "async_hooks" } : getExternals(),
-    experiments: isCloudflare ? { outputModule: true } : undefined,
+    externals: isCloudflare
+      ? { async_hooks: "async_hooks" }
+      : getExternals(isEsmOutput),
+    // The node externals preset emits require() for builtins even in module
+    // output; disable it for ESM so getExternals handles builtins through
+    // externalsType node-commonjs (createRequire) instead.
+    ...(isEsmOutput
+      ? {
+          externalsType: "node-commonjs" as const,
+          externalsPresets: { node: false },
+        }
+      : {}),
+    experiments: isCloudflare || isEsmOutput ? { outputModule: true } : undefined,
     resolve: {
       fallback: {
         process: false,
@@ -181,11 +213,25 @@ export function getRspackConfig(
           })
         : null,
       new InjectRuntimePlugin(),
+      isEsmOutput ? new EmitModulePackageJsonPlugin() : null,
       new CreateTypeDefinitionPlugin(),
       xmcpConfig.typescript?.skipTypeCheck ? null : new TsCheckerRspackPlugin(),
     ],
     module: {
       rules: [
+        // The prebuilt runtime files copied into .xmcp are CommonJS; when the
+        // application package.json declares "type": "module" they would be
+        // parsed as strict ESM and their require() calls left unresolved.
+        ...(isEsmOutput
+          ? [
+              {
+                test: /\.js$/,
+                include: runtimeFolderPath,
+                exclude: /import-map\.js$/,
+                type: "javascript/dynamic" as const,
+              },
+            ]
+          : []),
         {
           test: /\.(ts|tsx)$/,
           use: {

--- a/packages/compiler/src/compiler/get-bundler-config/plugins/index.ts
+++ b/packages/compiler/src/compiler/get-bundler-config/plugins/index.ts
@@ -1,7 +1,7 @@
 import { adapterOutputPath, runtimeFolderPath } from "@/utils/constants";
 import fs from "fs-extra";
 import path from "path";
-import { Compiler } from "@rspack/core";
+import { Compiler, Compilation, sources } from "@rspack/core";
 import { XmcpConfigOutputSchema } from "@/runtime-config";
 import { getRuntimeDirectoryPath } from "@/runtime-config";
 import { getXmcpConfig } from "@/compiler/compiler-context";
@@ -62,6 +62,32 @@ export function getRuntimeFileNames(): string[] {
   return fs
     .readdirSync(runtimeDirectoryPath)
     .filter((fileName) => fileName.endsWith(".js"));
+}
+
+/**
+ * Marks the output directory as ESM so the self-contained dist keeps running
+ * when deployed away from the project's package.json.
+ */
+export class EmitModulePackageJsonPlugin {
+  apply(compiler: Compiler) {
+    compiler.hooks.thisCompilation.tap(
+      "EmitModulePackageJsonPlugin",
+      (compilation) => {
+        compilation.hooks.processAssets.tap(
+          {
+            name: "EmitModulePackageJsonPlugin",
+            stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+          },
+          () => {
+            compilation.emitAsset(
+              "package.json",
+              new sources.RawSource(`{"type":"module"}\n`)
+            );
+          }
+        );
+      }
+    );
+  }
 }
 
 export function readRuntimeFile(fileName: string): string {

--- a/scripts/test-split-e2e.sh
+++ b/scripts/test-split-e2e.sh
@@ -65,7 +65,11 @@ prepare_consumer "xmcp-http" "$HTTP_APP"
 (cd "$HTTP_APP" && npx xmcp build >build.log 2>&1) \
   || { cat "$HTTP_APP/build.log" >&2; fail "xmcp build through the shim (HTTP consumer)"; }
 [ -f "$HTTP_APP/dist/http.js" ] || fail "shim build produced no dist/http.js"
-pass "shim resolves project-installed @xmcp-dev/compiler and builds"
+# The fixture declares "type": "module", so the build must emit ESM output
+# with the dist/package.json marker that keeps the artifact self-contained.
+grep -q '"type":"module"' "$HTTP_APP/dist/package.json" 2>/dev/null \
+  || fail "ESM build did not emit the dist/package.json module marker"
+pass "shim resolves project-installed @xmcp-dev/compiler and builds (ESM)"
 
 # --- Stage 3: HTTP artifact runs without node_modules ------------------------
 HTTP_DEPLOY="$WORK_DIR/deploy-http"
@@ -148,5 +152,35 @@ pass "missing @xmcp-dev/compiler exits non-zero with the install hint"
 (cd "$HTTP_APP" && node --input-type=module -e 'await import("xmcp/config")') \
   || fail "import(\"xmcp/config\")"
 pass "xmcp/config resolves via require and import"
+
+# --- Stage 7: CommonJS projects still get CommonJS output --------------------
+# Strip "type": "module" from the HTTP consumer and rebuild.
+node -e '
+const fs = require("fs");
+const pkgPath = process.argv[1];
+const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+delete pkg.type;
+fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+' "$HTTP_APP/package.json"
+(cd "$HTTP_APP" && rm -rf dist .xmcp && npx xmcp build >build-cjs.log 2>&1) \
+  || { cat "$HTTP_APP/build-cjs.log" >&2; fail "xmcp build in CommonJS mode"; }
+[ ! -f "$HTTP_APP/dist/package.json" ] \
+  || fail "CommonJS build unexpectedly emitted a dist/package.json marker"
+
+CJS_DEPLOY="$WORK_DIR/deploy-http-cjs"
+mkdir -p "$CJS_DEPLOY"
+cp -R "$HTTP_APP/dist" "$CJS_DEPLOY/dist"
+(cd "$CJS_DEPLOY" && node dist/http.js >server.log 2>&1) &
+SERVER_PID=$!
+for _ in $(seq "$READY_ATTEMPTS"); do
+  if curl -s -o /dev/null --max-time "$REQUEST_TIMEOUT_S" "http://127.0.0.1:$HTTP_PORT/mcp"; then break; fi
+  kill -0 "$SERVER_PID" 2>/dev/null || { cat "$CJS_DEPLOY/server.log" >&2; fail "CommonJS HTTP server exited early"; }
+  sleep "$READY_INTERVAL_S"
+done
+CJS_RES="$(mcp_post '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}')"
+echo "$CJS_RES" | grep -q '"5"' || { echo "$CJS_RES" >&2; fail "CommonJS HTTP tools/call add(2,3)"; }
+{ kill "$SERVER_PID" && wait "$SERVER_PID"; } 2>/dev/null || true
+SERVER_PID=""
+pass "CommonJS project still builds and serves CommonJS output"
 
 echo "All split E2E checks passed."

--- a/scripts/test-split-e2e.sh
+++ b/scripts/test-split-e2e.sh
@@ -8,6 +8,7 @@
 #   3. the same for a built stdio server
 #   4. `xmcp build` without @xmcp-dev/compiler fails with the install hint
 #   5. the xmcp/config export resolves from the packed runtime
+#   6. the React MCP App example exposes a standalone ESM UI resource
 #
 # Run from the repo root: bash scripts/test-split-e2e.sh
 set -euo pipefail
@@ -16,7 +17,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIXTURES="$REPO_ROOT/packages/xmcp/bench/fixtures"
 WORK_DIR="$(mktemp -d)"
 HTTP_PORT=3011 # fixed in bench/fixtures/xmcp-http/xmcp.config.ts
+REACT_APP_PORT=3001 # default in examples/mcp-app-react/xmcp.config.ts
 SERVER_PID=""
+READY_ATTEMPTS=50    # x READY_INTERVAL_S = 10s startup budget
+READY_INTERVAL_S=0.2 # poll interval while waiting for the port
+REQUEST_TIMEOUT_S=5  # per-request cap so a hung server fails fast
 
 cleanup() {
   if [ -n "$SERVER_PID" ]; then kill "$SERVER_PID" 2>/dev/null || true; fi
@@ -31,6 +36,16 @@ fail() {
 
 pass() {
   echo "PASS: $1"
+}
+
+wait_for_http_server() {
+  local port="$1" server_log="$2" label="$3"
+  for _ in $(seq "$READY_ATTEMPTS"); do
+    if curl -s -o /dev/null --max-time "$REQUEST_TIMEOUT_S" "http://127.0.0.1:$port/mcp"; then return; fi
+    kill -0 "$SERVER_PID" 2>/dev/null || { cat "$server_log" >&2; fail "$label server exited early"; }
+    sleep "$READY_INTERVAL_S"
+  done
+  fail "$label server did not accept connections"
 }
 
 # --- Stage 1: build and pack both packages -----------------------------------
@@ -79,27 +94,21 @@ cp -R "$HTTP_APP/dist" "$HTTP_DEPLOY/dist"
 SERVER_PID=$!
 
 # Poll until the server accepts connections instead of sleeping a fixed time.
-READY_ATTEMPTS=50    # x READY_INTERVAL_S = 10s startup budget
-READY_INTERVAL_S=0.2 # poll interval while waiting for the port
-REQUEST_TIMEOUT_S=5  # per-request cap so a hung server fails fast
-for _ in $(seq "$READY_ATTEMPTS"); do
-  if curl -s -o /dev/null --max-time "$REQUEST_TIMEOUT_S" "http://127.0.0.1:$HTTP_PORT/mcp"; then break; fi
-  kill -0 "$SERVER_PID" 2>/dev/null || { cat "$HTTP_DEPLOY/server.log" >&2; fail "HTTP server exited early"; }
-  sleep "$READY_INTERVAL_S"
-done
+wait_for_http_server "$HTTP_PORT" "$HTTP_DEPLOY/server.log" "HTTP"
 
 mcp_post() {
-  curl -s --max-time "$REQUEST_TIMEOUT_S" "http://127.0.0.1:$HTTP_PORT/mcp" \
+  local port="$1" payload="$2"
+  curl -s --max-time "$REQUEST_TIMEOUT_S" "http://127.0.0.1:$port/mcp" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
-    -d "$1"
+    -d "$payload"
 }
 
-INIT_RES="$(mcp_post '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"split-e2e","version":"0.0.0"}}}')"
+INIT_RES="$(mcp_post "$HTTP_PORT" '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"split-e2e","version":"0.0.0"}}}')"
 echo "$INIT_RES" | grep -q '"serverInfo"' || { echo "$INIT_RES" >&2; fail "HTTP initialize"; }
-LIST_RES="$(mcp_post '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}')"
+LIST_RES="$(mcp_post "$HTTP_PORT" '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}')"
 echo "$LIST_RES" | grep -q '"add"' || { echo "$LIST_RES" >&2; fail "HTTP tools/list"; }
-CALL_RES="$(mcp_post '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}')"
+CALL_RES="$(mcp_post "$HTTP_PORT" '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}')"
 echo "$CALL_RES" | grep -q '"5"' || { echo "$CALL_RES" >&2; fail "HTTP tools/call add(2,3)"; }
 { kill "$SERVER_PID" && wait "$SERVER_PID"; } 2>/dev/null || true
 SERVER_PID=""
@@ -172,15 +181,65 @@ mkdir -p "$CJS_DEPLOY"
 cp -R "$HTTP_APP/dist" "$CJS_DEPLOY/dist"
 (cd "$CJS_DEPLOY" && node dist/http.js >server.log 2>&1) &
 SERVER_PID=$!
-for _ in $(seq "$READY_ATTEMPTS"); do
-  if curl -s -o /dev/null --max-time "$REQUEST_TIMEOUT_S" "http://127.0.0.1:$HTTP_PORT/mcp"; then break; fi
-  kill -0 "$SERVER_PID" 2>/dev/null || { cat "$CJS_DEPLOY/server.log" >&2; fail "CommonJS HTTP server exited early"; }
-  sleep "$READY_INTERVAL_S"
-done
-CJS_RES="$(mcp_post '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}')"
+wait_for_http_server "$HTTP_PORT" "$CJS_DEPLOY/server.log" "CommonJS HTTP"
+CJS_RES="$(mcp_post "$HTTP_PORT" '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}')"
 echo "$CJS_RES" | grep -q '"5"' || { echo "$CJS_RES" >&2; fail "CommonJS HTTP tools/call add(2,3)"; }
 { kill "$SERVER_PID" && wait "$SERVER_PID"; } 2>/dev/null || true
 SERVER_PID=""
 pass "CommonJS project still builds and serves CommonJS output"
+
+# --- Stage 8: React MCP App builds and serves its UI from ESM dist/ ----------
+REACT_APP="$WORK_DIR/consumer-react-app"
+mkdir -p "$REACT_APP"
+cp "$REPO_ROOT/examples/mcp-app-react/package.json" \
+  "$REPO_ROOT/examples/mcp-app-react/tsconfig.json" \
+  "$REPO_ROOT/examples/mcp-app-react/xmcp.config.ts" \
+  "$REACT_APP"
+cp -R "$REPO_ROOT/examples/mcp-app-react/src" "$REACT_APP/src"
+node - "$REACT_APP/package.json" "$XMCP_TGZ" "$COMPILER_TGZ" <<'EOF'
+const fs = require("fs");
+const [pkgPath, xmcpTgz, compilerTgz] = process.argv.slice(2);
+const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+pkg.type = "module";
+pkg.dependencies.xmcp = `file:${xmcpTgz}`;
+pkg.devDependencies["@xmcp-dev/compiler"] = `file:${compilerTgz}`;
+fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+EOF
+(cd "$REACT_APP" && npm install --legacy-peer-deps --no-fund --no-audit >install.log 2>&1) \
+  || { cat "$REACT_APP/install.log" >&2; fail "npm install in React MCP App consumer"; }
+(cd "$REACT_APP" && npx xmcp build >build.log 2>&1) \
+  || { cat "$REACT_APP/build.log" >&2; fail "React MCP App build"; }
+[ -f "$REACT_APP/dist/http.js" ] || fail "React MCP App build produced no dist/http.js"
+grep -q '"type":"module"' "$REACT_APP/dist/package.json" 2>/dev/null \
+  || fail "React MCP App build did not emit the dist/package.json module marker"
+find "$REACT_APP/dist/client" -name '*.bundle.js' -type f | grep -q . \
+  || fail "React MCP App build produced no client bundle"
+
+REACT_DEPLOY="$WORK_DIR/deploy-react-app"
+mkdir -p "$REACT_DEPLOY"
+cp -R "$REACT_APP/dist" "$REACT_DEPLOY/dist"
+(cd "$REACT_DEPLOY" && node dist/http.js >server.log 2>&1) &
+SERVER_PID=$!
+wait_for_http_server "$REACT_APP_PORT" "$REACT_DEPLOY/server.log" "React MCP App HTTP"
+
+REACT_INIT_RES="$(mcp_post "$REACT_APP_PORT" '{"jsonrpc":"2.0","id":5,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"split-e2e-react-app","version":"0.0.0"}}}')"
+echo "$REACT_INIT_RES" | grep -q '"serverInfo"' \
+  || { echo "$REACT_INIT_RES" >&2; fail "React MCP App initialize"; }
+REACT_LIST_RES="$(mcp_post "$REACT_APP_PORT" '{"jsonrpc":"2.0","id":6,"method":"tools/list","params":{}}')"
+echo "$REACT_LIST_RES" | grep -q '"counter"' \
+  || { echo "$REACT_LIST_RES" >&2; fail "React MCP App tools/list"; }
+echo "$REACT_LIST_RES" | grep -q 'ui://app/counter.html' \
+  || { echo "$REACT_LIST_RES" >&2; fail "React MCP App tool UI resource metadata"; }
+REACT_CALL_RES="$(mcp_post "$REACT_APP_PORT" '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"counter","arguments":{"initialCount":4}}}')"
+echo "$REACT_CALL_RES" | grep -q '"structuredContent":{"args":{"initialCount":4}}' \
+  || { echo "$REACT_CALL_RES" >&2; fail "React MCP App tools/call structured content"; }
+REACT_RESOURCE_RES="$(mcp_post "$REACT_APP_PORT" '{"jsonrpc":"2.0","id":8,"method":"resources/read","params":{"uri":"ui://app/counter.html"}}')"
+echo "$REACT_RESOURCE_RES" | grep -q 'text/html;profile=mcp-app' \
+  || { echo "$REACT_RESOURCE_RES" >&2; fail "React MCP App resource MIME type"; }
+echo "$REACT_RESOURCE_RES" | grep -q 'id=\\"root\\"' \
+  || { echo "$REACT_RESOURCE_RES" >&2; fail "React MCP App resource HTML"; }
+{ kill "$SERVER_PID" && wait "$SERVER_PID"; } 2>/dev/null || true
+SERVER_PID=""
+pass "React MCP App builds as ESM and serves tool UI without node_modules"
 
 echo "All split E2E checks passed."


### PR DESCRIPTION
## Summary

- infer the build output format from the application's `package.json`: `"type": "module"` emits ESM bundles, anything else keeps CommonJS byte-for-byte unchanged — no new config field
- resolve node builtins through `createRequire` (`externalsType: node-commonjs`), since the node externals preset emits bare `require()` calls that are invalid in module output
- parse the prebuilt CommonJS runtime files with a scoped `javascript/dynamic` rule; a `"type": "module"` project otherwise makes the bundler treat them as strict ESM and leaves their `require()` calls unresolved
- write a `dist/package.json` module marker so the self-contained `dist` directory keeps running when deployed away from the project (`node dist/http.js`)
- convert `examples/http-transport` to `"type": "module"` as the runnable example and document the inference in the installation docs

## Type of Change

- [ ] Bug fixing
- [x] Adding a feature
- [x] Improving documentation
- [x] Adding or updating examples
- [ ] Performance - bundle size improvement (if applicable)

## Affected Packages

- [ ] `xmcp` (core framework)
- [ ] `create-xmcp-app`
- [ ] `init-xmcp`
- [ ] Plugins
- [x] Documentation
- [x] Examples
- [x] `@xmcp-dev/compiler`

## Contributor Checklist

- [x] I read `AGENTS.md` and the scoped rules for the areas I touched.
- [x] I kept this PR focused on the stated change.
- [x] I ran the relevant build, lint, test, or example checks.
- [x] I updated docs and a runnable example for user-facing behavior, or explained why an example does not fit.
- [x] I checked `REVIEW_RULES.md` for logging, timers, config shape, wrappers, compiler/loader changes, and stale examples.

## Testing

- `scripts/test-split-e2e.sh` extended with ESM assertions, a CommonJS regression stage, and a React MCP App stage; all 8 stages pass locally
- the React stage installs packed tarballs, builds `examples/mcp-app-react` as ESM, deploys `dist/` without `node_modules`, and verifies `initialize`, `tools/list`, `tools/call`, `resources/read`, `ui://` metadata, structured content, and generated widget HTML
- ESM HTTP and stdio servers answer `initialize`, `tools/list`, and `tools/call` from directories without `node_modules`
- `pnpm --dir packages/compiler typecheck` and `test:config` (38 passing); `pnpm --dir packages/xmcp test:adapters` (2 passing)
- `examples/http-transport` built as ESM and smoke-tested over HTTP

## Screenshots/Examples

`examples/http-transport` now demonstrates the ESM path; the CommonJS default is covered by the E2E regression stage.

## Related Issues

None.

