### PR TITLE
Improve the deployment guides for Replit, Vercel, Alpic, and Cloudflare

### DIFF
--- a/apps/website/content/docs/deployment/alpic.mdx
+++ b/apps/website/content/docs/deployment/alpic.mdx
@@ -8,15 +8,16 @@ description: "Alpic is a MCP-first cloud platform with one-click deployment for 
 
 Get started by bootstrapping a [new project](https://app.alpic.ai/new/clone?repositoryUrl=https://github.com/alpic-ai/mcp-server-template-xmcp).
 
-This command will clone the xmcp template repository and setup zero-configuration deployment to Alpic.
+This clones the xmcp template repository and sets up zero-configuration deployment to Alpic.
 
 ## Deploy an existing project
 
-You can deploy your xmcp server to Alpic in 2 steps:
+You can deploy your xmcp server to Alpic in three steps:
 
-1. Create a new account on [app.alpic.ai](https://app.alpic.ai/).
-2. Connect your Github account to Alpic, and select the repository you want to deploy.
+1. Sign in with GitHub on [app.alpic.ai](https://app.alpic.ai/) and select **New Project**.
+2. Connect your GitHub organization and import the repository you want to deploy. Alpic detects the framework and build commands from the repository automatically, and you can adjust the install and build commands before deploying.
+3. Add the environment variables your server needs and choose the branch to sync with production. Alpic deploys a new version every time you push to that branch.
 
-You can then access your servers's specific MCP analytics, logs, and evals in the [Alpic dashboard](https://app.alpic.ai/).
+Once deployed, you can test your server in the built-in playground and access its MCP analytics, logs, and evals in the [Alpic dashboard](https://app.alpic.ai/).
 
 Learn more about deploying xmcp to Alpic in the [Alpic documentation](https://docs.alpic.ai/).

--- a/apps/website/content/docs/deployment/cloudflare.mdx
+++ b/apps/website/content/docs/deployment/cloudflare.mdx
@@ -40,6 +40,8 @@ pnpm deploy
 npx wrangler deploy
 ```
 
+The first deploy prompts you to log in to your Cloudflare account. Once deployed, the Worker serves your configured endpoint, `/mcp` by default, on your `workers.dev` subdomain, along with a `/health` check route.
+
 ## Local development
 
 Run the watcher and Wrangler together:

--- a/apps/website/content/docs/deployment/replit.mdx
+++ b/apps/website/content/docs/deployment/replit.mdx
@@ -7,3 +7,33 @@ description: "Deploy your xmcp application to Replit with a single click."
 ---
 
 Get started by remixing the [xmcp Replit template](https://replit.com/@matt/MCP-on-Replit-TS#README.md).
+
+Remixing creates your own copy of the template in a Replit workspace. Run it to get a development endpoint in the Preview pane, then select **Publish** to deploy it to a production URL. Your server will be available at `https://<your-app>.replit.app/mcp`, ready to connect from any MCP client.
+
+## Deploy an existing project
+
+You can deploy your xmcp server to Replit in three steps:
+
+1. Import your repository at [replit.com/import](https://replit.com/import). For public repositories, you can also open `https://replit.com/github.com/<owner>/<repo>` directly.
+2. Configure the HTTP server to listen on `0.0.0.0`. Published Replit apps are not reachable when the server binds to xmcp's default host, `127.0.0.1`. Leave the port unset: Replit maps the first port your server opens to the public URL.
+3. Select **Publish** in the workspace and choose a deployment type. Autoscale is a good fit for stateless HTTP MCP servers.
+
+Your configuration should look like this:
+
+```typescript title="xmcp.config.ts"
+const config: XmcpConfig = {
+  http: {
+    host: "0.0.0.0",
+  },
+};
+
+export default config;
+```
+
+The run command should build the project and start the HTTP server:
+
+```bash
+npm run build && node dist/http.js
+```
+
+Learn more about deploying xmcp to Replit in the [Replit documentation](https://docs.replit.com/features/publishing/deployment-types).

--- a/apps/website/content/docs/deployment/vercel.mdx
+++ b/apps/website/content/docs/deployment/vercel.mdx
@@ -14,6 +14,10 @@ Then, [connect your Git repository](https://vercel.com/new) or [use Vercel CLI](
 vc deploy
 ```
 
+No configuration is needed: when Vercel builds your project, `xmcp build` detects the environment and emits the Vercel output automatically. Your server runs as a [Vercel Function](https://vercel.com/docs/functions) with [Fluid compute](https://vercel.com/docs/fluid-compute) by default, available at `https://<your-project>.vercel.app` on your configured endpoint, `/mcp` by default.
+
+The deployment serves the built HTTP server, so your project needs the HTTP transport enabled in `xmcp.config.ts`. You can also produce the same output outside of Vercel's build environment with `xmcp build --vercel`.
+
 ## Get started with Vercel CLI
 
 You can initialize a new xmcp app with Vercel CLI with the following command:
@@ -23,5 +27,7 @@ vc init xmcp
 ```
 
 This will clone the [xmcp example repository](https://github.com/vercel/vercel/tree/main/examples/xmcp) in a directory called `xmcp`.
+
+You can also run your project locally with [`vc dev`](https://vercel.com/docs/cli/dev), in addition to the project's own `dev` script.
 
 Learn more about deploying xmcp to Vercel in the [Vercel documentation](https://vercel.com/docs/frameworks/backend/xmcp).


### PR DESCRIPTION
## What

Expands the four deployment docs pages so each guide covers both the one-click/template path and deploying an existing project, with every claim verified against the framework source or the platform's official docs.

### Replit (was a single line)
- Explains the remix → run → **Publish** flow and the resulting `https://<your-app>.replit.app/mcp` URL.
- New **Deploy an existing project** section: GitHub import, binding to `0.0.0.0` (published Replit apps can't reach servers on xmcp's default `127.0.0.1`; Replit's troubleshooting docs confirm this), leaving the port unset so the `PORT` env fallback applies, and choosing an Autoscale deployment. Includes a copy-pasteable `xmcp.config.ts` and the build/start run command.

### Vercel
- Documents what zero-config actually means: `xmcp build` detects Vercel's build env (`VERCEL=1`, `packages/xmcp/src/cli.ts`) and emits the Build Output automatically; the server runs as a Vercel Function with Fluid compute at `https://<project>.vercel.app/mcp`.
- Notes the HTTP-transport requirement (the output packages `dist/http.js`) and the `xmcp build --vercel` flag, plus a `vc dev` mention.

### Alpic
- Replaces the vague two-step list with the concrete quickstart flow: GitHub sign-in / New Project, automatic framework + build-command detection with overrides, env vars, and production-branch sync. Mentions the playground. Fixes the "This command" wording (it's a link).

### Cloudflare
- Adds a short post-deploy paragraph: first-run `wrangler` login, the `workers.dev` URL with the `/mcp` endpoint, and the `/health` route (`runtime/platforms/cloudflare/worker.ts`).

## Verification

- All endpoint/port/flag claims checked against `packages/xmcp` source; platform claims checked against Vercel's xmcp docs, Replit's docs, and Alpic's quickstart. External links verified live.
- `prettier --check` passes; all four pages return HTTP 200 on the local dev server (markdown twins included). Website lint/build remain broken in this local env (Node 26 / BaseHub token), so CI is the authoritative build check.