### PR TITLE
Add icons to all docs sidebar page links and tighten section indent

### DIFF
--- a/apps/website/components/layout/docs.tsx
+++ b/apps/website/components/layout/docs.tsx
@@ -1,6 +1,12 @@
 "use client";
 import type * as PageTree from "fumadocs-core/page-tree";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import {
+  type ComponentType,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { cn } from "../../lib/cn";
 import { TreeContextProvider, useTreeContext } from "fumadocs-ui/contexts/tree";
 import Link from "fumadocs-core/link";
@@ -12,6 +18,32 @@ import {
   useSidebarOpenState,
 } from "@/hooks/use-sidebar-open-state";
 import { Icons } from "../icons";
+import {
+  ArchiveIcon,
+  AvatarIcon,
+  BarChartIcon,
+  CardStackPlusIcon,
+  ChatBubbleIcon,
+  ColorWheelIcon,
+  CubeIcon,
+  DownloadIcon,
+  FileTextIcon,
+  GlobeIcon,
+  GroupIcon,
+  HomeIcon,
+  IdCardIcon,
+  InfoCircledIcon,
+  LayersIcon,
+  LightningBoltIcon,
+  Link2Icon,
+  ListBulletIcon,
+  LockClosedIcon,
+  MagicWandIcon,
+  MagnifyingGlassIcon,
+  PaperPlaneIcon,
+  PersonIcon,
+  TokensIcon,
+} from "@radix-ui/react-icons";
 
 type SeparatorNode = Extract<PageTree.Node, { type: "separator" }>;
 type GroupedItem =
@@ -145,24 +177,50 @@ const linkVariants = cva(
   }
 );
 
-const sidebarIcons: Partial<Record<string, keyof typeof Icons>> = {
-  "/docs/adapters/nextjs": "nextjs",
-  "/docs/adapters/nestjs": "nestjs",
-  "/docs/adapters/express": "express",
-  "/docs/adapters/fastify": "fastify",
-  "/docs/deployment/vercel": "vercel",
-  "/docs/deployment/cloudflare": "cloudflare",
-  "/docs/deployment/alpic": "alpic",
-  "/docs/deployment/replit": "replit",
-  "/docs/integrations/auth0": "auth0",
-  "/docs/integrations/better-auth": "betterAuth",
-  "/docs/integrations/clerk": "clerk",
-  "/docs/integrations/commet": "commet",
-  "/docs/integrations/descope": "descope",
-  "/docs/integrations/polar": "polar",
-  "/docs/integrations/scalekit": "scalekit",
-  "/docs/integrations/workos": "workos",
-  "/docs/integrations/x402": "x402",
+const sidebarIcons: Partial<
+  Record<string, ComponentType<{ className?: string }>>
+> = {
+  "/docs": HomeIcon,
+  "/docs/getting-started/installation": DownloadIcon,
+  "/docs/getting-started/project-structure": ListBulletIcon,
+  "/docs/getting-started/connecting": Link2Icon,
+  "/docs/configuration/transports": PaperPlaneIcon,
+  "/docs/configuration/server-info": InfoCircledIcon,
+  "/docs/configuration/custom-directories": ArchiveIcon,
+  "/docs/configuration/bundler": CubeIcon,
+  "/docs/configuration/telemetry": BarChartIcon,
+  "/docs/core-concepts/tools": LightningBoltIcon,
+  "/docs/core-concepts/prompts": ChatBubbleIcon,
+  "/docs/core-concepts/resources": FileTextIcon,
+  "/docs/core-concepts/middlewares": LayersIcon,
+  "/docs/core-concepts/css": ColorWheelIcon,
+  "/docs/core-concepts/external-clients": GlobeIcon,
+  "/docs/authentication/api-key": LockClosedIcon,
+  "/docs/authentication/jwt": TokensIcon,
+  "/docs/authentication/oauth": PersonIcon,
+  "/docs/adapters/nextjs": Icons.nextjs,
+  "/docs/adapters/nestjs": Icons.nestjs,
+  "/docs/adapters/express": Icons.express,
+  "/docs/adapters/fastify": Icons.fastify,
+  "/docs/deployment/vercel": Icons.vercel,
+  "/docs/deployment/cloudflare": Icons.cloudflare,
+  "/docs/deployment/alpic": Icons.alpic,
+  "/docs/deployment/replit": Icons.replit,
+  "/docs/integrations/auth0": Icons.auth0,
+  "/docs/integrations/better-auth": Icons.betterAuth,
+  "/docs/integrations/clerk": Icons.clerk,
+  "/docs/integrations/commet": Icons.commet,
+  "/docs/integrations/descope": Icons.descope,
+  "/docs/integrations/polar": Icons.polar,
+  "/docs/integrations/scalekit": Icons.scalekit,
+  "/docs/integrations/workos": Icons.workos,
+  "/docs/integrations/x402": Icons.x402,
+  "/docs/discoverability/smithery": MagnifyingGlassIcon,
+  "/docs/discoverability/mcp-server-card": IdCardIcon,
+  "/docs/guides/xmcp-mcp-server": MagicWandIcon,
+  "/docs/guides/authentication": AvatarIcon,
+  "/docs/guides/roll-out-to-a-team": GroupIcon,
+  "/docs/guides/monetization": CardStackPlusIcon,
 };
 
 function SidebarItem({
@@ -181,8 +239,7 @@ function SidebarItem({
   const pathname = usePathname();
 
   if (item.type === "page") {
-    const iconKey = sidebarIcons[item.url];
-    const PageIcon = iconKey ? Icons[iconKey] : undefined;
+    const PageIcon = sidebarIcons[item.url];
     return (
       <Link
         href={item.url}
@@ -279,7 +336,7 @@ function SidebarSeparator({
         isOpen={isOpen}
         disableInitialAnimation={disableInitialAnimation}
       >
-        <div className="mt-1 pl-8 flex flex-col gap-1">{children}</div>
+        <div className="mt-1 pl-4 flex flex-col gap-1">{children}</div>
       </AnimatedGroup>
     </div>
   );

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-presence": "^1.1.5",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-icons':
+        specifier: ^1.3.2
+        version: 1.3.2(react@19.2.4)
       '@radix-ui/react-presence':
         specifier: ^1.1.5
         version: 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -268,7 +271,7 @@ importers:
         version: 5.0.0
       xmcp:
         specifier: latest
-        version: 0.6.13(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.23)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.1.13)
+        version: 0.7.1(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.23)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.1.13)
       zod:
         specifier: ^4.1.13
         version: 4.1.13
@@ -994,7 +997,7 @@ importers:
         version: 5.1.0(esbuild@0.28.1)
       xmcp:
         specifier: latest
-        version: 0.6.13(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.23)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.1))(zod@4.1.13)
+        version: 0.7.1(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.23)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.1))(zod@4.1.13)
       zod:
         specifier: ^4.0.10
         version: 4.1.13
@@ -3129,6 +3132,11 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-icons@1.3.2':
+    resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
+    peerDependencies:
+      react: ^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -4559,6 +4567,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -9131,8 +9140,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  xmcp@0.6.13:
-    resolution: {integrity: sha512-RGjaBr05bSaG/NF0OUHIUfX4fhZf4oKLF3PtN3fgHZAzpmVYUMyunPPLB+sE15p3fVG8q77nJCLmVyt+6XicbQ==}
+  xmcp@0.7.1:
+    resolution: {integrity: sha512-ehEtGf6H0wZ6KRF3qZCaufTFAjmP2d8BiSoSjjUndJvXN0ekKMVjQoTR11L2jn4T/qb40Z0wlaZtFcogzRHyxg==}
     hasBin: true
     peerDependencies:
       react: '>=19.0.0'
@@ -11029,6 +11038,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-icons@1.3.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
 
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
@@ -18154,7 +18167,7 @@ snapshots:
 
   ws@8.21.0: {}
 
-  xmcp@0.6.13(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.23)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.1))(zod@4.1.13):
+  xmcp@0.7.1(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.23)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1(esbuild@0.28.1))(zod@4.1.13):
     dependencies:
       '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       '@rspack/core': 1.6.7(@swc/helpers@0.5.15)
@@ -18173,7 +18186,7 @@ snapshots:
       - supports-color
       - webpack
 
-  xmcp@0.6.13(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.23)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.1.13):
+  xmcp@0.7.1(@cfworker/json-schema@4.1.1)(@swc/helpers@0.5.15)(postcss@8.5.23)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.104.1)(zod@4.1.13):
     dependencies:
       '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)
       '@rspack/core': 1.6.7(@swc/helpers@0.5.15)


### PR DESCRIPTION
## What

Follows up on #635 (company logo marks): every page link in the docs sidebar now has an icon, while section titles and folder labels stay icon-free.

- The existing brand marks (adapters, deployment, integrations) are unchanged. The remaining 24 pages get semantically matched icons from `@radix-ui/react-icons` — e.g. Installation → download, Connecting → link, Tools → lightning bolt, Prompts → chat bubble, Middlewares → layers, Transports → paper plane, Telemetry → bar chart, API Key → lock, JWT → tokens, OAuth → person, Smithery → magnifying glass, MCP Server Card → ID card, Monetization → card-stack-plus, Roll out to a team → group. (Radix has no key icon, hence the lock for API Key.)
- The `sidebarIcons` map in `components/layout/docs.tsx` now maps URL → component directly, so brand marks and Radix icons share one lookup and the same slot, sizing (`[&_svg]:size-4`), and color token as before.
- Tightened the section group indent from `pl-8` to `pl-4` to compensate for the width the icons add.

## Dependency note

Adds `@radix-ui/react-icons@1.3.2` (latest stable); the site already uses ten `@radix-ui/*` packages. Regenerating the lockfile also re-resolved the workspace's `xmcp: latest` specifiers from 0.6.13 to 0.7.1 — pnpm refreshes `latest` tags on any resolution pass, so this couldn't be split out. The `@xmldom/xmldom` deprecation marker in the lockfile diff is a transitive dep of xmcp 0.7.1.

## Verification

- `tsc --noEmit` and Prettier pass; all icon names verified against the package exports.
- Checked on the local dev server: all 41 sidebar page links render an icon, section headers render none, and the only `/docs` anchors without icons are the navbar link and prev/next pagination (not sidebar elements).