### PR TITLE
fix(compiler): declare serverCardHandler in the generated Next.js adapter types

### DIFF
--- a/.changeset/nextjs-server-card-types.md
+++ b/.changeset/nextjs-server-card-types.md
@@ -1,0 +1,5 @@
+---
+"@xmcp-dev/compiler": patch
+---
+
+Declare `serverCardHandler` in the generated Next.js adapter types so the documented server-card route passes application type checking.

--- a/packages/compiler/src/compiler/get-bundler-config/plugins/types/next.ts
+++ b/packages/compiler/src/compiler/get-bundler-config/plugins/types/next.ts
@@ -1,5 +1,6 @@
 export const nextJsTypeDefinition = `
 export const xmcpHandler: (req: Request) => Promise<Response>;
+export const serverCardHandler: (req: Request) => Response;
 export const withAuth: (handler: (req: Request) => Promise<Response>, authConfig: AuthConfig) => (req: Request) => Promise<Response>;
 export const resourceMetadataHandler: ({authorizationServers}: {authorizationServers: string[]}) => (req: Request) => Response;
 export const resourceMetadataOptions: (req: Request) => Response;


### PR DESCRIPTION
## Summary

Rebuilds the Next.js generated-type fix on the current `main` compiler layout introduced in xmcp 0.8.0.

- declares `serverCardHandler` in the generated `@xmcp/adapter` type definition;
- keeps the documented `/.well-known/mcp/server-card.json` route type-safe; and
- adds a patch changeset for `@xmcp-dev/compiler`.

## Verification

- Node 20.20.2
- `pnpm build`
- `pnpm --dir examples/with-nextjs build`
- Next.js production build includes `/.well-known/mcp/server-card.json`

## Release sequencing

Merge this before #641. Do not merge the generated Version Packages PR between #640 and #641; their patch changesets should aggregate into the same 0.8.1 release.
