### PR TITLE
fix(workos): declare CIMD/DCR fields on OAuthAuthorizationServerMetadata

### DIFF
--- a/.changeset/workos-as-metadata-types.md
+++ b/.changeset/workos-as-metadata-types.md
@@ -1,0 +1,5 @@
+---
+"@xmcp-dev/workos": patch
+---
+
+Declare optional `registration_endpoint` and `client_id_metadata_document_supported` fields on `OAuthAuthorizationServerMetadata` so the type matches the AuthKit RFC 8414 document the router already passes through.

--- a/packages/plugins/workos/src/types.ts
+++ b/packages/plugins/workos/src/types.ts
@@ -48,6 +48,8 @@ export interface OAuthAuthorizationServerMetadata {
   readonly code_challenge_methods_supported?: readonly string[];
   readonly token_endpoint_auth_methods_supported?: readonly string[];
   readonly scopes_supported?: readonly string[];
+  readonly registration_endpoint?: string;
+  readonly client_id_metadata_document_supported?: boolean;
 }
 
 export interface ClientContext {


### PR DESCRIPTION
## Summary

Adds two optional fields to `OAuthAuthorizationServerMetadata` in `@xmcp-dev/workos`:

```ts
readonly registration_endpoint?: string;
readonly client_id_metadata_document_supported?: boolean;
```

AuthKit returns both at its RFC 8414 `/.well-known/oauth-authorization-server` endpoint, and `workosRouter` passes the fetched document through verbatim, so the fields already reach clients at runtime — the type just didn't model them. They are optional because the static fallback object (used when the AuthKit fetch fails) intentionally omits CIMD/DCR.

This mirrors the clerk plugin, which already declares `registration_endpoint?` on its equivalent type.

Type-accuracy fix only — no runtime behavior change, so no docs/example update is needed.

## Checks

- `pnpm --filter @xmcp-dev/workos build` (plain tsc; type-check is the test) ✅

Closes #602