### PR TITLE
feat(xmcp): add extra.sample() sampling helper for tool handlers

### DIFF
--- a/.changeset/sampling-tool-helper.md
+++ b/.changeset/sampling-tool-helper.md
@@ -1,0 +1,5 @@
+---
+"xmcp": minor
+---
+
+Add `extra.sample()` so tool handlers can request LLM completions from the connected client via MCP sampling (`sampling/createMessage`), mirroring `extra.elicit()`. Supports text/image/audio messages, `systemPrompt`, `maxTokens`, `modelPreferences`, `temperature`, `stopSequences`, `includeContext`, and `metadata`, and exports the `SampleRequest`/`SampleResult` types. The `tools`/`toolChoice` sampling loop and task-augmented sampling are rejected with a clear error until the client tool-call flow is wired.

--- a/apps/website/content/docs/core-concepts/tools.mdx
+++ b/apps/website/content/docs/core-concepts/tools.mdx
@@ -385,6 +385,74 @@ same tool serves both client generations. To carry server state across rounds
 (remember: it round-trips through the client), mint and verify it with
 `createRequestStateCodec`, also re-exported from `xmcp`.
 
+### Sampling
+
+Use `extra.sample()` when a tool needs an LLM completion from the connected client. The client keeps control of model access, selection, and permissions, so the server needs no model API key. Sampling only works when the connected client advertises the `sampling` capability; other clients reject the request.
+
+The request takes `messages` (text, image, or audio content), a required `maxTokens`, and optional `systemPrompt`, `modelPreferences` (model hints plus cost/speed/intelligence priorities), `temperature`, `stopSequences`, `includeContext`, and `metadata`. The result contains the `model` the client picked, the assistant `content`, and an optional `stopReason`.
+
+```typescript title="src/tools/preview-sampling.ts"
+import { z } from "zod";
+import {
+  type InferSchema,
+  type ToolExtraArguments,
+  type ToolMetadata,
+} from "xmcp";
+
+export const schema = {
+  text: z.string().describe("Text for the client's model to summarize"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "preview-sampling",
+  description: "Preview a basic extra.sample() flow in MCPJam",
+  annotations: {
+    title: "Preview sampling",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+};
+
+export default async function previewSampling(
+  { text }: InferSchema<typeof schema>,
+  extra: ToolExtraArguments
+) {
+  const result = await extra.sample({
+    messages: [
+      {
+        role: "user",
+        content: { type: "text", text: `Summarize in one sentence:\n${text}` },
+      },
+    ],
+    systemPrompt: "You summarize text concisely.",
+    modelPreferences: {
+      speedPriority: 0.8,
+    },
+    maxTokens: 200,
+  });
+
+  return JSON.stringify(result, null, 2);
+}
+```
+
+#### Quick check with MCPJam
+
+1. From the repo root, run `pnpm --dir examples/http-transport dev`.
+2. In another terminal, run `npx @mcpjam/inspector@latest`.
+3. Connect MCPJam to `http://127.0.0.1:3001/mcp`.
+4. Call `preview-sampling` with any text.
+5. MCPJam shows the incoming sampling request for approval. Approving runs the completion with its configured model and the tool returns the `model`, `content`, and `stopReason` from the result.
+
+<Callout type="info">
+  Like `extra.elicit()`, `extra.sample()` uses server-initiated requests, which
+  exist on 2025-era MCP connections only. On protocol revision `2026-07-28` it
+  throws with a message pointing at `inputRequired.createMessage()` — the multi
+  round-trip replacement described above. Sampling with `tools`/`toolChoice` and
+  task-augmented sampling are not wired through xmcp yet and are rejected with a
+  clear error.
+</Callout>
+
 ### 2. Template Literal Handlers
 
 Return HTML directly to create interactive widgets. xmcp automatically generates

--- a/examples/http-transport/src/tools/preview-sampling.ts
+++ b/examples/http-transport/src/tools/preview-sampling.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import {
+  type InferSchema,
+  type ToolExtraArguments,
+  type ToolMetadata,
+} from "xmcp";
+
+export const schema = {
+  text: z.string().describe("Text for the client's model to summarize"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "preview-sampling",
+  description: "Preview a basic extra.sample() flow in MCPJam",
+  annotations: {
+    title: "Preview sampling",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+};
+
+export default async function previewSampling(
+  { text }: InferSchema<typeof schema>,
+  extra: ToolExtraArguments
+) {
+  const result = await extra.sample({
+    messages: [
+      {
+        role: "user",
+        content: { type: "text", text: `Summarize in one sentence:\n${text}` },
+      },
+    ],
+    systemPrompt: "You summarize text concisely.",
+    modelPreferences: {
+      speedPriority: 0.8,
+    },
+    maxTokens: 200,
+  });
+
+  return JSON.stringify(result, null, 2);
+}

--- a/examples/stdio-transport/src/tools/preview-sampling.ts
+++ b/examples/stdio-transport/src/tools/preview-sampling.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import {
+  type InferSchema,
+  type ToolExtraArguments,
+  type ToolMetadata,
+} from "xmcp";
+
+export const schema = {
+  text: z.string().describe("Text for the client's model to summarize"),
+};
+
+export const metadata: ToolMetadata = {
+  name: "preview-sampling",
+  description: "Preview a basic extra.sample() flow over stdio",
+  annotations: {
+    title: "Preview sampling",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+};
+
+export default async function previewSampling(
+  { text }: InferSchema<typeof schema>,
+  extra: ToolExtraArguments
+) {
+  const result = await extra.sample({
+    messages: [
+      {
+        role: "user",
+        content: { type: "text", text: `Summarize in one sentence:\n${text}` },
+      },
+    ],
+    systemPrompt: "You summarize text concisely.",
+    modelPreferences: {
+      speedPriority: 0.8,
+    },
+    maxTokens: 200,
+  });
+
+  return JSON.stringify(result, null, 2);
+}

--- a/packages/xmcp/src/index.ts
+++ b/packages/xmcp/src/index.ts
@@ -13,6 +13,8 @@ export type {
   ToolExtraArguments,
   InferSchema,
   ElicitResult,
+  SampleRequest,
+  SampleResult,
 } from "./types/tool";
 export type { McpClientInfo } from "./types/client-info";
 export type { PromptMetadata } from "./types/prompt";

--- a/packages/xmcp/src/runtime/utils/__tests__/sampling.test.ts
+++ b/packages/xmcp/src/runtime/utils/__tests__/sampling.test.ts
@@ -1,0 +1,188 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import {
+  SdkError,
+  SdkErrorCode,
+  type ServerContext,
+} from "@modelcontextprotocol/server";
+import { sampleFromTool } from "../sampling";
+import type { SampleRequest, SampleResult } from "@/types/tool";
+
+const SAMPLE_RESULT: SampleResult = {
+  model: "stub-model",
+  role: "assistant",
+  content: {
+    type: "text",
+    text: "stubbed completion",
+  },
+};
+
+type RecordedCall = {
+  params: Record<string, unknown>;
+  options?: Record<string, unknown>;
+};
+
+const createServerContextStub = (options: { samplingError?: Error } = {}) => {
+  const calls: RecordedCall[] = [];
+  const ctx = {
+    sessionId: undefined,
+    mcpReq: {
+      requestSampling: async (
+        params: RecordedCall["params"],
+        requestOptions?: RecordedCall["options"]
+      ) => {
+        calls.push({ params, options: requestOptions });
+        if (options.samplingError) {
+          throw options.samplingError;
+        }
+        return SAMPLE_RESULT;
+      },
+    },
+  } as unknown as ServerContext;
+
+  return { calls, ctx };
+};
+
+const VALID_REQUEST: SampleRequest = {
+  messages: [
+    {
+      role: "user",
+      content: { type: "text", text: "Summarize this changelog." },
+    },
+  ],
+  systemPrompt: "You are a release-note writer.",
+  maxTokens: 200,
+};
+
+test("sampleFromTool forwards the normalized params to requestSampling", async () => {
+  const { calls, ctx } = createServerContextStub();
+
+  const result = await sampleFromTool(ctx, VALID_REQUEST, { timeout: 1000 });
+
+  assert.strictEqual(calls.length, 1);
+  assert.deepStrictEqual(calls[0].params, VALID_REQUEST);
+  assert.deepStrictEqual(calls[0].options, { timeout: 1000 });
+  assert.deepStrictEqual(result, SAMPLE_RESULT);
+});
+
+test("sampleFromTool forwards modelPreferences and sampling options", async () => {
+  const { calls, ctx } = createServerContextStub();
+
+  await sampleFromTool(ctx, {
+    ...VALID_REQUEST,
+    modelPreferences: {
+      hints: [{ name: "claude" }],
+      costPriority: 0.2,
+      speedPriority: 0.3,
+      intelligencePriority: 0.9,
+    },
+    temperature: 0.5,
+    stopSequences: ["END"],
+    includeContext: "none",
+  });
+
+  const params = calls[0].params;
+  assert.deepStrictEqual(params.modelPreferences, {
+    hints: [{ name: "claude" }],
+    costPriority: 0.2,
+    speedPriority: 0.3,
+    intelligencePriority: 0.9,
+  });
+  assert.strictEqual(params.temperature, 0.5);
+  assert.deepStrictEqual(params.stopSequences, ["END"]);
+  assert.strictEqual(params.includeContext, "none");
+});
+
+test("sampleFromTool rejects non-object requests", async () => {
+  const { calls, ctx } = createServerContextStub();
+
+  await assert.rejects(
+    sampleFromTool(ctx, "summarize" as unknown as SampleRequest),
+    /Sampling request must be a plain object\./
+  );
+  assert.strictEqual(calls.length, 0);
+});
+
+test("sampleFromTool rejects requests without messages", async () => {
+  const { calls, ctx } = createServerContextStub();
+
+  await assert.rejects(
+    sampleFromTool(ctx, {
+      messages: [],
+      maxTokens: 100,
+    }),
+    /Sampling requires at least one message\./
+  );
+  assert.strictEqual(calls.length, 0);
+});
+
+test("sampleFromTool rejects requests without numeric maxTokens", async () => {
+  const { calls, ctx } = createServerContextStub();
+
+  await assert.rejects(
+    sampleFromTool(ctx, {
+      messages: VALID_REQUEST.messages,
+    } as SampleRequest),
+    /Sampling requires a numeric maxTokens\./
+  );
+  assert.strictEqual(calls.length, 0);
+});
+
+test("sampleFromTool rejects tools and toolChoice explicitly", async () => {
+  const { calls, ctx } = createServerContextStub();
+
+  await assert.rejects(
+    sampleFromTool(ctx, {
+      ...VALID_REQUEST,
+      tools: [],
+      toolChoice: { mode: "auto" },
+    } as unknown as SampleRequest),
+    /Sampling request key\(s\) not supported by xmcp yet: tools, toolChoice\./
+  );
+  assert.strictEqual(calls.length, 0);
+});
+
+test("sampleFromTool rejects unknown request keys", async () => {
+  const { calls, ctx } = createServerContextStub();
+
+  await assert.rejects(
+    sampleFromTool(ctx, {
+      ...VALID_REQUEST,
+      prompt: "typo-field",
+    } as unknown as SampleRequest),
+    /Sampling request includes unsupported key\(s\): prompt\./
+  );
+  assert.strictEqual(calls.length, 0);
+});
+
+test("sampleFromTool rejects invalid message content", async () => {
+  const { calls, ctx } = createServerContextStub();
+
+  await assert.rejects(
+    sampleFromTool(ctx, {
+      messages: [
+        {
+          role: "user",
+          content: { type: "text" },
+        },
+      ],
+      maxTokens: 100,
+    } as unknown as SampleRequest),
+    /Sampling message at index 0 requires string text content\./
+  );
+  assert.strictEqual(calls.length, 0);
+});
+
+test("sampleFromTool explains the 2026-07-28 replacement when the era rejects it", async () => {
+  const { ctx } = createServerContextStub({
+    samplingError: new SdkError(
+      SdkErrorCode.MethodNotSupportedByProtocolVersion,
+      "method not supported"
+    ),
+  });
+
+  await assert.rejects(
+    sampleFromTool(ctx, VALID_REQUEST),
+    /inputRequired\.createMessage/
+  );
+});

--- a/packages/xmcp/src/runtime/utils/sampling.ts
+++ b/packages/xmcp/src/runtime/utils/sampling.ts
@@ -1,0 +1,154 @@
+import {
+  SdkError,
+  SdkErrorCode,
+  ServerContext,
+  CreateMessageRequestParamsBase,
+} from "@modelcontextprotocol/server";
+import type {
+  SampleRequest,
+  SampleResult,
+  ToolRequestOptions,
+} from "@/types/tool";
+
+const ALLOWED_SAMPLE_REQUEST_KEYS = new Set([
+  "_meta",
+  "includeContext",
+  "maxTokens",
+  "messages",
+  "metadata",
+  "modelPreferences",
+  "stopSequences",
+  "systemPrompt",
+  "temperature",
+]);
+// Part of the SDK request params, but the client tool-loop and task flows are
+// not wired through xmcp yet. Reject them explicitly instead of sending
+// requests the framework cannot follow through on.
+const UNSUPPORTED_SAMPLE_REQUEST_KEYS = new Set([
+  "task",
+  "toolChoice",
+  "tools",
+]);
+
+const SUPPORTED_MESSAGE_CONTENT_TYPES = new Set(["text", "image", "audio"]);
+
+export async function sampleFromTool(
+  ctx: ServerContext,
+  request: SampleRequest,
+  options?: ToolRequestOptions
+): Promise<SampleResult> {
+  const params = normalizeSampleRequest(request);
+
+  try {
+    return (await ctx.mcpReq.requestSampling(params, options)) as SampleResult;
+  } catch (error) {
+    if (
+      error instanceof SdkError &&
+      error.code === SdkErrorCode.MethodNotSupportedByProtocolVersion
+    ) {
+      throw new Error(
+        "extra.sample() is not available on protocol revision 2026-07-28: " +
+          "server-initiated sampling was replaced by multi round-trip " +
+          "requests. Return inputRequired({ ... }) with " +
+          "inputRequired.createMessage(...) from the tool handler instead " +
+          "(re-exported from xmcp); the client fulfils the embedded requests " +
+          "and retries the tool call."
+      );
+    }
+    throw error;
+  }
+}
+
+function normalizeSampleRequest(
+  request: SampleRequest
+): CreateMessageRequestParamsBase {
+  assertPlainObject(request, "Sampling request must be a plain object.");
+
+  const requestKeys = Object.keys(request);
+  const unsupportedKeys = requestKeys.filter((key) =>
+    UNSUPPORTED_SAMPLE_REQUEST_KEYS.has(key)
+  );
+
+  if (unsupportedKeys.length > 0) {
+    throw new Error(
+      `Sampling request key(s) not supported by xmcp yet: ${unsupportedKeys.join(", ")}.`
+    );
+  }
+
+  const extraKeys = requestKeys.filter(
+    (key) => !ALLOWED_SAMPLE_REQUEST_KEYS.has(key)
+  );
+
+  if (extraKeys.length > 0) {
+    throw new Error(
+      `Sampling request includes unsupported key(s): ${extraKeys.join(", ")}.`
+    );
+  }
+
+  if (!Array.isArray(request.messages) || request.messages.length === 0) {
+    throw new Error("Sampling requires at least one message.");
+  }
+
+  for (const [index, message] of request.messages.entries()) {
+    assertValidMessage(index, message);
+  }
+
+  if (typeof request.maxTokens !== "number") {
+    throw new Error("Sampling requires a numeric maxTokens.");
+  }
+
+  return request as CreateMessageRequestParamsBase;
+}
+
+function assertValidMessage(index: number, message: unknown): void {
+  assertPlainObject(
+    message,
+    `Sampling message at index ${index} must be a plain object.`
+  );
+
+  if (message.role !== "user" && message.role !== "assistant") {
+    throw new Error(
+      `Sampling message at index ${index} requires role "user" or "assistant".`
+    );
+  }
+
+  const content = message.content;
+  assertPlainObject(
+    content,
+    `Sampling message at index ${index} requires a content object.`
+  );
+
+  const contentType = content.type;
+  if (
+    typeof contentType !== "string" ||
+    !SUPPORTED_MESSAGE_CONTENT_TYPES.has(contentType)
+  ) {
+    throw new Error(
+      `Sampling message at index ${index} uses unsupported content type "${String(contentType)}". Supported types are text, image, and audio.`
+    );
+  }
+
+  if (contentType === "text" && typeof content.text !== "string") {
+    throw new Error(
+      `Sampling message at index ${index} requires string text content.`
+    );
+  }
+
+  if (
+    (contentType === "image" || contentType === "audio") &&
+    (typeof content.data !== "string" || typeof content.mimeType !== "string")
+  ) {
+    throw new Error(
+      `Sampling message at index ${index} requires base64 data and a mimeType.`
+    );
+  }
+}
+
+function assertPlainObject(
+  value: unknown,
+  errorMessage: string
+): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(errorMessage);
+  }
+}

--- a/packages/xmcp/src/runtime/utils/transformers/tool.ts
+++ b/packages/xmcp/src/runtime/utils/transformers/tool.ts
@@ -14,6 +14,7 @@ import {
   mapImplementationToClientInfo,
 } from "@/runtime/utils/client-info";
 import { elicitFromTool } from "../elicitation";
+import { sampleFromTool } from "../sampling";
 import { validateContent } from "../validators";
 
 function validateAgainstOutputSchema(
@@ -134,6 +135,7 @@ function createToolExtraArguments(ctx: ServerContext): ToolExtraArguments {
     sendRequest: (request, resultSchema, options) =>
       ctx.mcpReq.send(request, resultSchema as never, options),
     elicit: (request, options) => elicitFromTool(ctx, request, options),
+    sample: (request, options) => sampleFromTool(ctx, request, options),
     inputResponses: ctx.mcpReq.inputResponses,
     requestState: ctx.mcpReq.requestState,
   };

--- a/packages/xmcp/src/types/tool.ts
+++ b/packages/xmcp/src/types/tool.ts
@@ -1,6 +1,10 @@
 import { z } from "zod/v3";
 import type { ZodType as ZodTypeV4, infer as inferV4 } from "zod";
-import type { ElicitResult as McpElicitResult } from "@modelcontextprotocol/server";
+import type {
+  CreateMessageRequestParamsBase,
+  CreateMessageResult,
+  ElicitResult as McpElicitResult,
+} from "@modelcontextprotocol/server";
 import { UIMetadata } from "./ui-meta";
 import type { McpClientInfo } from "./client-info";
 
@@ -43,6 +47,10 @@ type InferCompatibleZodType<T extends CompatibleZodType> =
 export type ToolSchema = Record<string, CompatibleZodType>;
 export type ToolOutputSchema = Record<string, CompatibleZodType>;
 export type ElicitResult = McpElicitResult;
+// Task-augmented sampling is not wired through xmcp yet; the base params also
+// exclude the tools/toolChoice loop, which needs client tool-call handling.
+export type SampleRequest = Omit<CreateMessageRequestParamsBase, "task">;
+export type SampleResult = CreateMessageResult;
 
 export interface ToolRequestOptions {
   /** Progress notification callback */
@@ -181,6 +189,12 @@ export interface ToolExtraArguments {
     request: ElicitRequest,
     options?: ToolRequestOptions
   ) => Promise<ElicitResult>;
+
+  /** Requests an LLM completion from the connected client */
+  sample: (
+    request: SampleRequest,
+    options?: ToolRequestOptions
+  ) => Promise<SampleResult>;
 
   /**
    * Multi round-trip input responses carried by a retried request


### PR DESCRIPTION
## Summary

Implements #541: tool handlers can now request LLM completions from the connected client with `extra.sample()`, mirroring the existing `extra.elicit()` pattern. The helper validates and normalizes the request, then sends `sampling/createMessage` via the SDK's `requestSampling` on the current request context, so the client keeps control of model access, selection, and permissions and the server needs no model API key.

```ts
const result = await extra.sample({
  messages: [{ role: "user", content: { type: "text", text: "Summarize…" } }],
  systemPrompt: "You summarize text concisely.",
  modelPreferences: { speedPriority: 0.8 },
  maxTokens: 200,
});
// result.model, result.content, result.stopReason
```

Built on current `main` (post SDK v2 / #641): `sampleFromTool(ctx: ServerContext, …)` calls `ctx.mcpReq.requestSampling()`, and on a 2026-07-28-era request it rethrows the SDK's era rejection with a friendly message pointing at `inputRequired.createMessage(...)` — exactly the dual-era behavior `extra.elicit()` has.

### What's included

- `packages/xmcp/src/runtime/utils/sampling.ts` — `sampleFromTool()`, a sibling of `elicitation.ts` with the same validate-then-send shape and the same `SdkErrorCode.MethodNotSupportedByProtocolVersion` era guard. Supports `messages` (text/image/audio), `systemPrompt`, `maxTokens`, `modelPreferences`, `temperature`, `stopSequences`, `includeContext`, and `metadata`.
- `sample` wired into `createToolExtraArguments` next to `elicit`; `SampleRequest`/`SampleResult` types exported from `xmcp` (reusing the SDK's `CreateMessageRequestParamsBase`/`CreateMessageResult`). No new package subpath.
- Unit tests (`sampling.test.ts`, 9 cases) following the `tool-extra.test.ts` `ServerContext`-stub pattern, including the 2026-07-28 era-rejection message.
- Docs: `### Sampling` section in `core-concepts/tools.mdx` after the `inputRequired` section, with an MCPJam quick check and a dual-era callout mirroring elicitation's.
- Runnable `preview-sampling` example tools in `examples/http-transport` and `examples/stdio-transport`.
- Changeset (minor, `xmcp`).

### Deliberately out of scope

`tools`/`toolChoice` in sampling requests and task-augmented sampling are **rejected with a clear error** rather than silently dropped — the client tool-loop needs its own design on top of the 2026-07-28 `inputRequired` flow. Multi-turn conversations without client tools already work by calling `extra.sample()` again with the accumulated messages.

Sampling is a client capability, so no server capability registration and no transport changes. No hidden session state: the request rides the in-flight request context, exactly like elicitation.

### Verification

- `packages/xmcp` builds cleanly; 18/18 runtime unit tests pass (`node --import tsx --test`).
- Both touched examples build.
- **End-to-end over stdio (legacy era)**: an SDK v1 client with a `sampling` handler receives `sampling/createMessage` with the normalized params and the tool returns the full `SampleResult` (model, content, stopReason).
- **2026-07-28 era**: covered by the unit test asserting the `inputRequired.createMessage` guidance.
- **HTTP**: verified the sampling request is delivered to the client on the in-flight stream with correct params; response routing on the stateless transport behaves identically to `extra.elicit()` (tested both side by side with a raw SDK client).

Supersedes the earlier community PR #542 (credit to @FiammaMuscari for the original take) — that branch predates both the runtime/compiler split (#633) and the SDK v2 migration (#641), so this is a fresh, thinner implementation of the same feature on current `main`.

Closes #541